### PR TITLE
fix: URL 优先落盘 + fake-ip SSRF 放行 + 用户教程

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,6 +10,15 @@ XAI_MODEL=grok-imagine-image-lite
 # 可选: contain(默认，补边不裁切) / cover(裁切铺满) / stretch(拉伸) / backend(保留后端原图)
 MICU_GROK_SIZE_MODE=contain
 
+# API 响应格式策略：
+#   auto（默认）— 先 url 请求并下载落盘，失败再重试 API response_format=b64_json
+#   url — 仅 url； b64_json — 仅 b64_json
+# MICU_RESPONSE_FORMAT=auto
+# 可信 CDN 域名（逗号分隔）；fake-ip 环境下 URL fallback 下载用
+# MICU_TRUSTED_DOWNLOAD_HOSTS=oss.filenest.top
+# 是否允许可信 CDN 解析到 198.18.0.0/15（Clash/Surge fake-ip）；默认 1
+# MICU_ALLOW_FAKE_IP_DOWNLOAD=1
+
 # 输出目录（不填默认 ~/Pictures/micu-out）
 # macOS / Linux:
 MICU_SAVE_DIR=~/Pictures/micu-out

--- a/README.md
+++ b/README.md
@@ -38,6 +38,13 @@
 
 ---
 
+## 使用教程
+
+面向 Cursor / Claude Code / Codex 用户的完整 MCP 使用指南见 [docs/MCP使用教程.md](docs/MCP使用教程.md)，
+涵盖工具选型、尺寸规则、环境变量与故障排查（含 Clash/Surge fake-ip 落盘问题）。
+
+---
+
 ## Grok 与 GPT Image2 功能差异
 
 | 能力 | `gpt-image-2` / `gpt-image-2-pro` | 米醋 Grok 图像模型 |

--- a/docs/MCP使用教程.md
+++ b/docs/MCP使用教程.md
@@ -1,0 +1,637 @@
+# micu-image-mcp 使用教程
+
+面向 Cursor / Claude Code / Codex 等 MCP 客户端用户，帮助你快速理解并正确使用「米醋画图 MCP」的全部能力。
+
+---
+
+## 一、这是什么？
+
+**micu-image-mcp** 是一个 MCP（Model Context Protocol）服务器，把 [米醋 API](https://www.micuapi.ai) 的图像生成能力封装成 5 个工具，让 AI 助手可以直接：
+
+- 根据文字描述生成图片
+- 编辑已有图片（换背景、改局部、加细节等）
+- 批量处理多张图片
+- 融合多张参考图生成新图
+- 查询当前配置与能力边界
+
+生成的图片会**自动保存到本地磁盘**，返回结果中包含文件的绝对路径，方便你在 IDE 或文件管理器中打开。
+
+默认主通道模型为 `gpt-image-2` / `gpt-image-2-pro`。可选配置 Grok 图像通道（`grok-imagine-image-*` 系列）。
+
+---
+
+## 二、安装与配置（Cursor）
+
+### 2.1 一键安装（推荐）
+
+```bash
+git clone https://github.com/Subaru486desuwa/micu-image-mcp.git
+cd micu-image-mcp
+python install.py
+```
+
+安装脚本会检查 Python ≥ 3.10、安装依赖、配置 API Key、写入 Claude/Codex 配置，并做一次 MCP 握手验证。
+
+非交互安装：
+
+```bash
+MICU_API_KEY=sk-你的密钥 \
+MICU_SAVE_DIR=~/Pictures/micu-out \
+python install.py --yes
+```
+
+### 2.2 手动配置 Cursor
+
+在 `~/.cursor/mcp.json` 中添加：
+
+```json
+{
+  "mcpServers": {
+    "micu-image-mcp": {
+      "command": "/path/to/micu-image-mcp/.venv/bin/python",
+      "args": ["/path/to/micu-image-mcp/server.py"],
+      "env": {
+        "MICU_API_KEY": "sk-你的Image2分组密钥",
+        "MICU_SAVE_DIR": "/home/你的用户名/Pictures/micu-out",
+        "MICU_SAVE_DIR_ROOT": "/home/你的用户名/Pictures/micu-out"
+      }
+    }
+  }
+}
+```
+
+配置完成后**重启 Cursor**，在 MCP 面板中确认 `micu-image-mcp` 显示为已连接。
+
+### 2.3 环境变量说明
+
+| 变量 | 默认值 | 说明 |
+|------|--------|------|
+| `MICU_API_KEY` | 空 | 米醋 **Image2 分组** token，必须能访问 `gpt-image-2` / `gpt-image-2-pro` |
+| `MICU_BASEURL` | `https://www.micuapi.ai` | 米醋 API 地址 |
+| `MICU_MODEL` | `gpt-image-2` | 默认模型 |
+| `MICU_GROK_API_KEY` | 空 | 可选，米醋 **Grok 图像分组** token |
+| `XAI_MODEL` | `grok-imagine-image-lite` | Grok 默认模型 |
+| `MICU_GROK_SIZE_MODE` | `contain` | Grok 输出尺寸归一化策略：`contain` / `cover` / `stretch` / `backend` |
+| `MICU_SAVE_DIR` | `~/Pictures/micu-out` | 默认输出目录 |
+| `MICU_SAVE_DIR_ROOT` | 同 `MICU_SAVE_DIR` | 安全根目录，所有输出必须在其下 |
+| `MICU_USE_SHELL_PROXY` | `0` | 设为 `1` 才读取系统 shell 代理 |
+
+> **重要**：Image2 分组和 Grok 分组通常是两把不同的 Key。把 Grok Key 填进 `MICU_API_KEY` 会出现「分组 grok 下模型 gpt-image-2 无可用渠道」错误。
+
+---
+
+## 三、连通性验证
+
+### 3.1 本次实测结果
+
+| 检查项 | 状态 | 说明 |
+|--------|------|------|
+| Cursor MCP 配置 | ✅ 正常 | `micu-image-mcp` 已写入 `~/.cursor/mcp.json` |
+| `server_info` 调用 | ✅ 正常 | API Key 已配置，输出目录为 `/home/wcx/Pictures/micu-out` |
+| `image_generate` 调用 | ⚠️ 部分成功 | API 请求可达，但图片落盘在当前环境受阻（见下方） |
+
+### 3.2 如何自行验证
+
+在 Cursor 对话中让 AI 执行：
+
+```
+请调用 micu-image-mcp 的 server_info，告诉我当前配置和能力矩阵。
+```
+
+预期返回 `api_key_configured: true` 及完整的 `capability_matrix`。
+
+再测试生图：
+
+```
+请用 image_generate 生成一张 1024x1024 的红苹果简笔画，basename 设为 test_apple。
+```
+
+成功时返回示例：
+
+```json
+{
+  "ok": true,
+  "model": "gpt-image-2",
+  "size": "1024x1024",
+  "saved": [
+    {
+      "path": "/home/wcx/Pictures/micu-out/test_apple.png",
+      "size_bytes": 123456,
+      "actual_size": "1254x1254",
+      "actual_megapixels": 1.57
+    }
+  ],
+  "errors": [],
+  "notes": []
+}
+```
+
+### 3.3 当前环境已知问题与解决
+
+本次测试遇到两类错误：
+
+**① HTTP 524 超时**
+
+```
+HTTP 524: A timeout occurred
+```
+
+原因：米醋上游在高负载时响应超过 Cloudflare 120 秒限制。  
+处理：MCP 已内置自动重试；仍失败时改小尺寸（如 `1024x1024`）或稍后重试。
+
+**② SSRF 防护拦截图片下载（旧版本 / 已关闭 fake-ip 放行时）**
+
+```
+保存失败: 下载 URL host 'oss.filenest.top' 指向受限地址 198.18.1.23（私网/环回/链路本地/保留），已拒绝（SSRF 防护）
+```
+
+原因：chat stream fallback 等路径仍返回 CDN URL，需二次下载。若系统 DNS 将 `oss.filenest.top` 解析到 `198.18.1.x`（Clash / Surge **fake-ip**），且 `MICU_ALLOW_FAKE_IP_DOWNLOAD=0` 时会被拒绝。
+
+**当前版本默认已双层修复，通常无需改代理：**
+
+1. **主路径** `MICU_RESPONSE_FORMAT=auto`（默认）：先请求 `url` 并下载落盘，失败再重试 `b64_json`
+2. **URL 路径** `MICU_ALLOW_FAKE_IP_DOWNLOAD=1`（默认）：可信 CDN（`oss.filenest.top`）解析到 fake-ip 时仍允许下载，**不影响 VPN 正常功能**
+
+若仍失败，可检查 `server_info` 中 `response_format` / `allow_fake_ip_download` 是否为预期值；或临时在代理中将 `oss.filenest.top` 加入 fake-ip 排除列表。
+
+---
+
+## 四、五个工具详解
+
+### 工具选择速查
+
+```mermaid
+flowchart TD
+    A[用户需求] --> B{有参考图吗?}
+    B -->|没有| C[image_generate<br/>文生图]
+    B -->|1 张| D{要改原图还是融合风格?}
+    B -->|多张| E{每张独立改还是融合成 1 张?}
+    D -->|修改/编辑| F[image_edit<br/>单图编辑]
+    D -->|风格参考画新图| G[image_multi_reference]
+    E -->|每张做同样操作| H[image_batch_edit<br/>批量编辑]
+    E -->|综合参考画 1 张新图| G
+    I[不确定尺寸/能力] --> J[server_info<br/>查询配置]
+```
+
+---
+
+### 4.1 `server_info` — 配置与能力查询
+
+**用途**：在调用任何生图工具之前，先了解当前运行时配置、尺寸规则、各工具能力边界。
+
+**参数**：无
+
+**返回要点**：
+
+- `api_key_configured` / `grok_api_key_configured`：密钥是否配置
+- `recommended_sizes`：各档位推荐尺寸
+- `capability_matrix`：各工具 × 各尺寸档的可用性
+- `retry_policy`：重试与并发策略
+- `safety_constraints`：安全限制（输出目录、输入大小等）
+
+**使用场景**：
+
+- 首次使用前确认配置是否正确
+- 不确定该用哪个尺寸时查阅 `recommended_sizes`
+- 排查「为什么 4K 编辑被拒绝」等问题
+
+**示例对话**：
+
+> 请先调用 server_info，告诉我 2K 文生图是否可用，以及推荐尺寸。
+
+---
+
+### 4.2 `image_generate` — 文生图
+
+**用途**：根据文字描述从零生成 1～10 张图片。
+
+**何时使用**：
+
+- 用户说「画一张…」「生成一张…」「创建 logo/海报/壁纸」
+- **没有**提供任何参考图
+
+**参数**：
+
+| 参数 | 类型 | 必填 | 说明 |
+|------|------|------|------|
+| `prompt` | string | ✅ | 图像描述，1–2000 字符 |
+| `size` | string \| null | | `"WxH"` 格式，如 `"1024x1024"`；留空则从 prompt 关键字自动推断 |
+| `n` | int | | 生成张数 1–10；1K 可多张并发，≥2K 强制 n=1 |
+| `model` | string \| null | | `gpt-image-2` 或 `gpt-image-2-pro`；留空按尺寸自动选择 |
+| `save_dir` | string \| null | | 输出目录，必须在 `MICU_SAVE_DIR_ROOT` 下 |
+| `basename` | string \| null | | 文件名前缀，仅允许 `[A-Za-z0-9_\-.]` |
+| `api_key` | string \| null | | 临时覆盖环境变量中的 Key |
+
+**尺寸速查**：
+
+| 档位 | 推荐尺寸 | 实际输出 | 速度 |
+|------|----------|----------|------|
+| 1K | `1024x1024`, `1536x1024`, `1024x1536` | ~1.57MP（福利档） | 快，~30s |
+| 2K | `2048x2048`, `2048x1152`, `1152x2048` | 真 2K | ~80s，自动 pro |
+| 4K | `3840x2160`, `2160x3840` | 真 4K | ~80s，自动 pro |
+
+> W 和 H 必须是 **8 的倍数**。`1920x1080` 等 ≤2.25MP 的尺寸会被压到 ~1.57MP。
+
+**Prompt 写法建议**：
+
+- 中英文均可；gpt-image-2 文字渲染能力强，可直接在 prompt 中写要显示的文字
+- 越具体越好：风格、视角、光线、主体、细节程度
+- 例：`"极简风格寿司吉祥物 logo，柔和粉彩配色，白色背景，居中构图"`
+
+**示例对话**：
+
+> 帮我生成一张赛博朋克东京夜景 4K 横屏壁纸。
+
+AI 应调用：
+
+```
+image_generate(
+  prompt="cyberpunk Tokyo at night, neon lights, rain reflections, cinematic",
+  size="3840x2160"
+)
+```
+
+> 画 4 张可爱猫咪贴纸让我挑选。
+
+```
+image_generate(
+  prompt="cute cat sticker, kawaii style, transparent-friendly composition",
+  size="1024x1024",
+  n=4
+)
+```
+
+---
+
+### 4.3 `image_edit` — 单图编辑
+
+**用途**：接受 1 张本地图片 + 修改指令，输出编辑后的图片。
+
+**何时使用**：
+
+- 用户提供 **1 张图**，要修改、替换、添加或删除某部分
+- 对刚生成的图做后续调整
+
+**参数**：
+
+| 参数 | 类型 | 必填 | 说明 |
+|------|------|------|------|
+| `prompt` | string | ✅ | 修改指令 |
+| `image_path` | string | ✅ | 输入图路径（绝对或相对），支持 PNG/JPG/WebP |
+| `mask_path` | string \| null | | 可选 alpha mask PNG；透明区域 = 编辑区，不透明 = 保留 |
+| `size` | string | | 输出尺寸，默认 `1024x1024` |
+| `model` | string \| null | | 模型，≥2K 自动切 pro |
+| `save_dir` | string \| null | | 输出目录 |
+| `basename` | string \| null | | 文件名前缀 |
+| `api_key` | string \| null | | 临时覆盖 Key |
+
+**Mask 工作原理**：
+
+- `mask_path` 指向与输入图同尺寸的 PNG
+- **alpha=0（透明）** 的像素 → 要修改的区域
+- **alpha=255（不透明）** 的像素 → 保持原样
+- 不传 mask → 模型自由决定修改范围
+
+**尺寸限制**：
+
+| 档位 | 可用性 | 说明 |
+|------|--------|------|
+| 1K | ✅ 稳定 | ~1.57MP，~10s |
+| 2K | ⚠️ best-effort | 约 2/3 成功真 2K；失败时 fallback ~1.57MP，2–4 分钟 |
+| 4K | ❌ 已禁用 | 入口直接拒绝；请用两步法（见下文） |
+
+**示例对话**：
+
+> 把 `/home/wcx/Pictures/portrait.jpg` 的背景换成日落海滩，人物保持不变。
+
+```
+image_edit(
+  prompt="replace background with a sunset beach, keep the subject pixel-identical",
+  image_path="/home/wcx/Pictures/portrait.jpg"
+)
+```
+
+> 只把头发改成银色（我有 mask 文件）。
+
+```
+image_edit(
+  prompt="change hair color to silver",
+  image_path="/home/wcx/Pictures/x.png",
+  mask_path="/home/wcx/Pictures/x_mask.png"
+)
+```
+
+---
+
+### 4.4 `image_batch_edit` — 批量编辑
+
+**用途**：对多张输入图分别应用**同一条**修改指令，N 张进 → N 张出。
+
+**何时使用**：
+
+- 多张图要做相同操作：批量换底、统一调色、加水印、转素描风格等
+
+**何时不用**：
+
+- 只有 1 张图 → 用 `image_edit`
+- 多张图作风格参考画 1 张新图 → 用 `image_multi_reference`
+
+**参数**：
+
+| 参数 | 类型 | 必填 | 说明 |
+|------|------|------|------|
+| `prompt` | string | ✅ | 应用到每张图的指令 |
+| `image_paths` | string[] | ✅ | 输入图路径列表，建议 2–20 张 |
+| `size` | string | | 仅支持 1K 档，默认 `1024x1024` |
+| `model` | string \| null | | 模型 |
+| `save_dir` | string \| null | | 输出目录；文件名为 `batch_<时间戳>_<序号>.png` |
+| `api_key` | string \| null | | 临时覆盖 Key |
+
+**并发策略**：
+
+- non-pro 模型：5 并发
+- pro 模型：串行 + 1.5s 间隔
+- 单张失败不影响其他张
+
+**示例对话**：
+
+> 把这 3 张产品图都转成铅笔素描风格。
+
+```
+image_batch_edit(
+  prompt="convert to pencil sketch style",
+  image_paths=[
+    "/home/wcx/Pictures/product_a.jpg",
+    "/home/wcx/Pictures/product_b.jpg",
+    "/home/wcx/Pictures/product_c.jpg"
+  ],
+  size="1024x1024"
+)
+```
+
+---
+
+### 4.5 `image_multi_reference` — 多图融合参考
+
+**用途**：输入 2–10 张参考图 + prompt，综合所有图的视觉信息，输出 **1 张全新**的图片。
+
+**何时使用**：
+
+- 「这几张是同一产品不同角度，画一个新角度」
+- 「按这些图的风格画一张 X」
+- 「这是 logo 主图和辅助图，做成海报」
+
+**与 `image_batch_edit` 的区别**：
+
+| | `image_batch_edit` | `image_multi_reference` |
+|--|-------------------|------------------------|
+| 输入 | N 张图 | 2–10 张图 |
+| 输出 | N 张图（每张独立改） | **1 张**新图（融合参考） |
+| 场景 | 批量做同样操作 | 综合多张图的风格/元素 |
+
+**参数**：
+
+| 参数 | 类型 | 必填 | 说明 |
+|------|------|------|------|
+| `prompt` | string | ✅ | 综合指令 |
+| `image_paths` | string[] | ✅ | 2–10 张参考图路径 |
+| `size` | string | | 输出尺寸，默认 `1024x1024` |
+| `model` | string \| null | | 模型 |
+| `save_dir` | string \| null | | 输出目录 |
+| `basename` | string \| null | | 文件名前缀 |
+| `api_key` | string \| null | | 临时覆盖 Key |
+
+**限制**：
+
+- 单张参考图建议 ≤2MB，总输入 ≤8MB
+- 1K 稳定 ~1.57MP；2K best-effort；4K 已禁用
+
+**示例对话**：
+
+> 把草图、角色、背景这三张图融合成一张电影海报。
+
+```
+image_multi_reference(
+  prompt="combine these into a single cinematic poster with dramatic lighting",
+  image_paths=[
+    "/home/wcx/Pictures/sketch.png",
+    "/home/wcx/Pictures/character.png",
+    "/home/wcx/Pictures/background.png"
+  ]
+)
+```
+
+---
+
+## 五、尺寸与能力矩阵
+
+### 5.1 核心规则
+
+1. **W/H 必须是 8 的倍数**（image2 路径）
+2. **W/H 范围 256–4096**
+3. **≤2.25MP**（如 1024²、1920×1080）→ 被代理压到 **~1.57MP** 福利档
+4. **≥2K 自动切 `gpt-image-2-pro`**，且 **n 强制为 1**
+5. **2K/4K 有跨进程锁**：多窗口同时请求会串行排队
+
+### 5.2 各场景能力
+
+| 场景 | 工具 | 可靠性 | 实际输出 |
+|------|------|--------|----------|
+| 1K 文生图 | `image_generate` | ✅ 可靠 | ~1.57MP |
+| 2K/4K 文生图 | `image_generate` | ✅ 真分辨率 | 2048² / 3840×2160 |
+| 1K 单图编辑 | `image_edit` | ✅ 可靠 | ~1.57MP |
+| 2K 带参考图编辑 | `image_edit` | ⚠️ best-effort | 约 2/3 真 2K |
+| 1K 多图融合 | `image_multi_reference` | ✅ 可靠 | ~1.57MP |
+| 2K 多图融合 | `image_multi_reference` | ⚠️ best-effort | 约 2/3 真 2K |
+| 4K 带参考图 | `image_edit` / `image_multi_reference` | ❌ 禁用 | 入口拒绝 |
+| 批量编辑 ≥2K | `image_batch_edit` | ❌ 禁用 | 仅 1K |
+
+### 5.3 两步法：带参考图想要 4K
+
+由于 4K + 参考图会触发 Cloudflare 524 超时，官方推荐：
+
+1. 先用 `image_edit` 或 `image_multi_reference` 出 1K/2K 综合图
+2. 再用 `image_generate` 描述同一场景升分辨率：
+
+```
+image_generate(
+  prompt="同一场景的高清 4K 版本，保持构图与风格一致：...",
+  size="3840x2160"
+)
+```
+
+---
+
+## 六、Grok 通道（可选）
+
+配置 `MICU_GROK_API_KEY` 后，可在 `model` 参数中指定 Grok 模型：
+
+| 模型 | 用途 |
+|------|------|
+| `grok-imagine-image-lite` | 快速文生图（默认） |
+| `grok-imagine-image` | 标准质量 |
+| `grok-imagine-image-pro` | 高质量 |
+| `grok-imagine-image-edit` | 单图参考/编辑 |
+
+**与 image2 的主要差异**：
+
+| 能力 | image2 | Grok |
+|------|--------|------|
+| 文生图 4K | ✅ | ❌（映射到 2K） |
+| 局部 mask | ✅ | ❌（忽略） |
+| 批量编辑 | ✅ | ❌ |
+| 尺寸约束 | 8 倍数、4096 边长 | 仅校验 WxH 格式 |
+| 实际输出尺寸 | 2K/4K 文生图可精确 | 不保证等于请求尺寸 |
+
+Grok 尺寸归一化由 `MICU_GROK_SIZE_MODE` 控制：
+
+| 值 | 行为 |
+|----|------|
+| `contain` | 等比缩放，补边（默认） |
+| `cover` | 等比缩放，居中裁切铺满 |
+| `stretch` | 拉伸（可能变形） |
+| `backend` | 保留后端原始像素 |
+
+---
+
+## 七、返回结果字段说明
+
+所有生图工具返回 JSON 字典，通用字段：
+
+| 字段 | 类型 | 说明 |
+|------|------|------|
+| `ok` | bool | 是否至少成功 1 张/次 |
+| `model` | string | 实际使用的模型 |
+| `size` | string | 请求的尺寸 |
+| `saved` | list/dict | 成功保存的文件信息 |
+| `errors` | list | 失败描述列表 |
+| `notes` | list | 路由决策、降级、尺寸偏差等说明 |
+
+`saved` 中每项包含：
+
+| 字段 | 说明 |
+|------|------|
+| `path` | 文件绝对路径 |
+| `size_bytes` | 文件字节数 |
+| `actual_size` | 从图片 header 读出的真实像素（如 `"1254x1254"`） |
+| `actual_megapixels` | 实际百万像素 |
+
+> **注意**：1K 档请求 `1024x1024` 时，`actual_size` 常为 `1254x1254`（~1.57MP 福利档），属正常现象。
+
+---
+
+## 八、安全机制
+
+MCP 内置多项安全限制：
+
+| 限制 | 说明 |
+|------|------|
+| 输出目录牢笼 | 所有输出必须在 `MICU_SAVE_DIR_ROOT` 下 |
+| basename 校验 | 仅允许 `[A-Za-z0-9_\-.]`，禁止 `/`、`..` |
+| 输入图校验 | 按 magic bytes 验证为 PNG/JPEG/WebP/GIF |
+| 输入大小 | 单图 ≤4MB；多图参考总和 ≤8MB |
+| 响应大小 | 远端响应 ≤25MB |
+| SSRF 防护 | 拒绝真内网地址；可信 CDN + fake-ip（198.18.0.0/15）在默认配置下放行 |
+| base_url 锁定 | 运行期不可通过 tool 参数修改 API 地址 |
+
+---
+
+## 九、常见错误与排查
+
+| 错误信息 | 原因 | 解决方案 |
+|----------|------|----------|
+| `未配置 API key` | 环境变量未设置 | 在 mcp.json 的 `env` 中配置 `MICU_API_KEY` |
+| `分组 grok 下模型 gpt-image-2 无可用渠道` | Key 分组填错 | Image2 Key 填 `MICU_API_KEY`，Grok Key 填 `MICU_GROK_API_KEY` |
+| `size W/H 必须是 8 的倍数` | 尺寸不符合约束 | 改为如 `1024x1024`、`2048x1152` |
+| `HTTP 524: timeout` | 上游超时 | 改小尺寸或稍后重试；2K/4K 高负载时偶发 |
+| `SSRF 防护` + `198.18.x.x` | 旧版或 `MICU_ALLOW_FAKE_IP_DOWNLOAD=0` | 升级 MCP 或设 `MICU_ALLOW_FAKE_IP_DOWNLOAD=1`；`auto` 模式下 URL 失败会自动重试 `b64_json` |
+| `image_path 不存在` | 路径错误 | 使用绝对路径 |
+| `size=3840x2160 (4K) 在 image_edit 已禁用` | 4K 编辑不可用 | 改用 2K 或两步法 |
+| `basename 含非法字符` | 文件名不规范 | 仅用字母数字下划线连字符 |
+| `save_dir 必须在 MICU_SAVE_DIR_ROOT 之下` | 输出目录越界 | 使用配置的默认目录或其子目录 |
+
+---
+
+## 十、实用对话模板
+
+### 文生图
+
+```
+请用 micu-image-mcp 生成一张 [描述]，尺寸 [WxH]，保存为 [basename]。
+```
+
+### 编辑已有图
+
+```
+请编辑图片 [绝对路径]，[修改要求]。
+```
+
+### 批量处理
+
+```
+请对以下图片批量 [操作]：
+- /path/to/a.jpg
+- /path/to/b.jpg
+- /path/to/c.jpg
+```
+
+### 多图融合
+
+```
+请参考以下图片的风格/元素，生成一张 [新图描述]：
+- /path/to/ref1.png
+- /path/to/ref2.png
+```
+
+### 查询能力
+
+```
+请先调用 server_info，告诉我当前支持哪些尺寸和模型。
+```
+
+---
+
+## 十一、输出文件位置
+
+默认保存目录：`~/Pictures/micu-out`（可通过 `MICU_SAVE_DIR` 修改）
+
+文件命名规则：
+
+| 工具 | 默认前缀 |
+|------|----------|
+| `image_generate` | `gen_<时间戳>` 或 `gen_<时间戳>_<序号>` |
+| `image_edit` | `edit_<时间戳>` |
+| `image_batch_edit` | `batch_<时间戳>_<序号>` |
+| `image_multi_reference` | `multiref_<时间戳>` |
+
+生成成功后，AI 会返回 `saved[].path`，你可以直接在文件管理器或 IDE 中打开。
+
+---
+
+## 十二、卸载
+
+```bash
+# 仅移除 MCP 配置（Claude + Codex）
+python install.py --reset
+
+# 同时卸载 pip 包
+python -m pip uninstall -y micu-image-mcp
+```
+
+Cursor 需手动从 `~/.cursor/mcp.json` 删除 `micu-image-mcp` 节。
+
+---
+
+## 附录：工具 API 速查表
+
+| 工具 | 必填参数 | 主要用途 |
+|------|----------|----------|
+| `server_info` | 无 | 查询配置与能力 |
+| `image_generate` | `prompt` | 文生图 |
+| `image_edit` | `prompt`, `image_path` | 单图编辑 |
+| `image_batch_edit` | `prompt`, `image_paths` | 批量同指令编辑 |
+| `image_multi_reference` | `prompt`, `image_paths`（2–10 张） | 多图融合成 1 张 |
+
+---
+
+*文档版本：基于 micu-image-mcp 当前代码库生成，实测环境为 Cursor + WSL2 + Linux。*

--- a/micu_image_mcp/config.py
+++ b/micu_image_mcp/config.py
@@ -4,6 +4,7 @@ server.py 顶部 from .config import * 让原代码引用方式不变。
 """
 from __future__ import annotations
 
+import ipaddress
 import os
 import re
 from pathlib import Path
@@ -36,6 +37,30 @@ GROK_SIZE_MODE = os.environ.get("MICU_GROK_SIZE_MODE", "contain").strip().lower(
 # 米醋是国内站，不应走 shell 的 SOCKS/HTTP 代理；默认 trust_env=False。
 # 设 MICU_USE_SHELL_PROXY=1 才让 httpx 拾取 HTTPS_PROXY/HTTP_PROXY/ALL_PROXY。
 _TRUST_ENV = os.environ.get("MICU_USE_SHELL_PROXY", "").strip() in ("1", "true", "yes")
+
+# API 响应格式策略：
+#   auto（默认）— 先 url 请求并下载落盘，失败再重试 API response_format=b64_json
+#   url — 仅 url； b64_json — 仅 b64_json
+_rf_raw = os.environ.get("MICU_RESPONSE_FORMAT", "auto").strip().lower()
+if _rf_raw == "url":
+    API_RESPONSE_FORMAT = "url"
+    RESPONSE_FORMATS_TO_TRY: tuple[str, ...] = ("url",)
+elif _rf_raw == "b64_json":
+    API_RESPONSE_FORMAT = "b64_json"
+    RESPONSE_FORMATS_TO_TRY = ("b64_json",)
+else:
+    API_RESPONSE_FORMAT = "auto"
+    RESPONSE_FORMATS_TO_TRY = ("url", "b64_json")
+
+# URL 下载 SSRF：可信 CDN 主机 + fake-ip（198.18.0.0/15）放行，真内网永不放行。
+_trusted_hosts_raw = os.environ.get("MICU_TRUSTED_DOWNLOAD_HOSTS", "oss.filenest.top").strip()
+TRUSTED_DOWNLOAD_HOSTS: frozenset[str] = frozenset(
+    h.strip().lower() for h in _trusted_hosts_raw.split(",") if h.strip()
+) if _trusted_hosts_raw else frozenset({"oss.filenest.top"})
+ALLOW_FAKE_IP_DOWNLOAD = os.environ.get(
+    "MICU_ALLOW_FAKE_IP_DOWNLOAD", "1"
+).strip().lower() in ("1", "true", "yes")
+FAKE_IP_NETWORK = ipaddress.ip_network("198.18.0.0/15")
 
 # save_dir 的安全根目录：tool 调用方无论传什么 save_dir，都不能写到此根之外。
 # 默认 = 用户家目录下的 Pictures/micu-out；可用 MICU_SAVE_DIR_ROOT 覆盖。
@@ -133,6 +158,8 @@ __all__ = [
     "DEFAULT_BASEURL", "API_KEY", "DEFAULT_MODEL",
     "GROK_BASEURL", "GROK_API_KEY", "XAI_MODEL", "GROK_SIZE_MODE",
     "_TRUST_ENV", "_SAVE_ROOT", "DEFAULT_SAVE_DIR", "_INPUT_ROOT",
+    "API_RESPONSE_FORMAT", "RESPONSE_FORMATS_TO_TRY",
+    "TRUSTED_DOWNLOAD_HOSTS", "ALLOW_FAKE_IP_DOWNLOAD", "FAKE_IP_NETWORK",
     "PRO_MODEL", "NONPRO_MODEL",
     "GROK_MODEL_ALIASES", "GROK_AVAILABLE_MODELS",
     "GROK_ASPECT_RATIO_CHOICES", "GROK_SIZE_MODES",

--- a/micu_image_mcp/save.py
+++ b/micu_image_mcp/save.py
@@ -11,7 +11,13 @@ from pathlib import Path
 from typing import Any
 from urllib.parse import urlsplit
 
-from .config import MAX_RESPONSE_BYTES, _SAVE_ROOT
+from .config import (
+    MAX_RESPONSE_BYTES,
+    _SAVE_ROOT,
+    TRUSTED_DOWNLOAD_HOSTS,
+    ALLOW_FAKE_IP_DOWNLOAD,
+    FAKE_IP_NETWORK,
+)
 from .extract import _extract_image_payload, _parse_response
 from .io_safety import _detect_actual_size, _validate_image_bytes
 from .routing import _size_note
@@ -33,14 +39,47 @@ _DOWNLOAD_TOTAL_TIMEOUT_SECONDS = 180.0
 _ALLOWED_DOWNLOAD_SCHEMES = ("http", "https")
 
 
-def _ip_is_blocked(ip: "ipaddress.IPv4Address | ipaddress.IPv6Address") -> bool:
+def _host_is_trusted(host: str) -> bool:
+    """hostname 是否匹配可信 CDN 下载白名单（精确或后缀，如 cdn.oss.filenest.top）。"""
+    h = host.lower().rstrip(".")
+    for trusted in TRUSTED_DOWNLOAD_HOSTS:
+        t = trusted.lower()
+        if h == t or h.endswith("." + t):
+            return True
+    return False
+
+
+def _is_fake_ip(ip: "ipaddress.IPv4Address | ipaddress.IPv6Address") -> bool:
+    if isinstance(ip, ipaddress.IPv6Address) and ip.ipv4_mapped is not None:
+        ip = ip.ipv4_mapped
+    try:
+        return ip in FAKE_IP_NETWORK
+    except TypeError:
+        return False
+
+
+def _ip_is_blocked(
+    ip: "ipaddress.IPv4Address | ipaddress.IPv6Address",
+    *,
+    host: str | None = None,
+) -> bool:
     # IPv4-mapped IPv6（如 ::ffff:127.0.0.1）先解包再判，避免绕过。
     if isinstance(ip, ipaddress.IPv6Address) and ip.ipv4_mapped is not None:
         ip = ip.ipv4_mapped
-    return (
+    # Clash/Surge fake-ip（198.18.0.0/15）：须在 is_private 之前判（Py3.14+ 将该段标为 private）。
+    if _is_fake_ip(ip):
+        if ALLOW_FAKE_IP_DOWNLOAD and host and _host_is_trusted(host):
+            return False
+        return True
+    # 真内网/环回/链路本地/多播/unspecified：无论是否可信域名一律拒绝。
+    if (
         ip.is_private or ip.is_loopback or ip.is_link_local
-        or ip.is_reserved or ip.is_multicast or ip.is_unspecified
-    )
+        or ip.is_multicast or ip.is_unspecified
+    ):
+        return True
+    if ip.is_reserved:
+        return True
+    return False
 
 
 def _assert_download_url_safe(url: str) -> None:
@@ -75,7 +114,7 @@ def _assert_download_url_safe(url: str) -> None:
             ip = ipaddress.ip_address(addr.split("%")[0])  # 去掉 IPv6 zone id
         except ValueError as e:
             raise ImageSaveError(f"下载 URL 解析出非法地址 {addr!r}") from e
-        if _ip_is_blocked(ip):
+        if _ip_is_blocked(ip, host=host):
             raise ImageSaveError(
                 f"下载 URL host {host!r} 指向受限地址 {ip}"
                 f"（私网/环回/链路本地/保留），已拒绝（SSRF 防护）"
@@ -292,6 +331,52 @@ async def _save_image_url(
     return await _save_validated_bytes(raw, save_dir, basename, source_label=f"远端图 {url[:80]}")
 
 
+async def _save_extracted_payload(
+    b64: str | None,
+    url: str | None,
+    save_dir: Path,
+    basename: str,
+    notes: list[str],
+    *,
+    normalize_size: str | None = None,
+    normalize_mode: str | None = None,
+    normalize_label: str = "图片",
+) -> tuple[Path, tuple[int, int] | None, int]:
+    """优先 URL 下载；失败且响应含 b64 时改用 b64_json。"""
+    url_err: Exception | None = None
+    if url:
+        try:
+            return await _save_image_url(
+                url,
+                save_dir,
+                basename,
+                normalize_size=normalize_size,
+                normalize_mode=normalize_mode,
+                notes=notes,
+                normalize_label=normalize_label,
+            )
+        except Exception as e:  # noqa: BLE001
+            url_err = e
+            if not b64:
+                raise
+            note = f"URL 下载失败（{e}）→ 改用响应内 b64_json"
+            if note not in notes:
+                notes.append(note)
+    if b64:
+        return await _save_image_b64(
+            b64,
+            save_dir,
+            basename,
+            normalize_size=normalize_size,
+            normalize_mode=normalize_mode,
+            notes=notes,
+            normalize_label=normalize_label,
+        )
+    if url_err is not None:
+        raise url_err
+    raise ImageSaveError("响应中未识别到图片")
+
+
 async def _save_first_payload_from_response(
     text: str,
     out_dir: Path,
@@ -306,28 +391,16 @@ async def _save_first_payload_from_response(
     resp = _parse_response(text)
     b64, url = _extract_image_payload(resp)
     try:
-        if b64:
-            p, actual, size_bytes = await _save_image_b64(
-                b64,
-                out_dir,
-                stem,
-                normalize_size=normalize_size,
-                normalize_mode=normalize_mode,
-                notes=notes,
-                normalize_label=normalize_label,
-            )
-        elif url:
-            p, actual, size_bytes = await _save_image_url(
-                url,
-                out_dir,
-                stem,
-                normalize_size=normalize_size,
-                normalize_mode=normalize_mode,
-                notes=notes,
-                normalize_label=normalize_label,
-            )
-        else:
-            return None, "响应中未识别到图片"
+        p, actual, size_bytes = await _save_extracted_payload(
+            b64,
+            url,
+            out_dir,
+            stem,
+            notes,
+            normalize_size=normalize_size,
+            normalize_mode=normalize_mode,
+            normalize_label=normalize_label,
+        )
     except Exception as e:  # noqa: BLE001
         return None, f"保存失败: {e}"
 
@@ -345,5 +418,5 @@ __all__ = [
     "ImageSaveError",
     "_normalized_image_bytes_sync", "_maybe_normalize_image_bytes",
     "_save_validated_bytes", "_save_image_b64", "_save_image_url",
-    "_save_first_payload_from_response",
+    "_save_extracted_payload", "_save_first_payload_from_response",
 ]

--- a/micu_image_mcp/save.py
+++ b/micu_image_mcp/save.py
@@ -295,29 +295,31 @@ async def _save_image_url(
     # SSRF 防护：下载前校验 url（DNS 解析走线程，不阻塞事件循环）。
     await asyncio.to_thread(_assert_download_url_safe, url)
     cx = _get_http_client()
-    # stream 提前读 Content-Length 拒超大响应；follow_redirects=False 防经 3xx 重定向到内网绕过校验；
-    # asyncio.timeout 给整段下载加墙钟上限，防慢滴流无限挂起独占大图锁。
-    try:
-        async with asyncio.timeout(_DOWNLOAD_TOTAL_TIMEOUT_SECONDS):
-            async with cx.stream("GET", url, timeout=120.0, follow_redirects=False) as r:
-                r.raise_for_status()
-                cl = r.headers.get("content-length")
-                if cl and cl.isdigit() and int(cl) > MAX_RESPONSE_BYTES:
+    # stream 提前读 Content-Length 拒超大响应；follow_redirects=False 防经 3xx 重定向到内网绕过校验。
+    async def _download_raw() -> bytes:
+        async with cx.stream("GET", url, timeout=120.0, follow_redirects=False) as r:
+            r.raise_for_status()
+            cl = r.headers.get("content-length")
+            if cl and cl.isdigit() and int(cl) > MAX_RESPONSE_BYTES:
+                raise ImageSaveError(
+                    f"远端图 Content-Length={int(cl)/1024/1024:.1f}MB 超过 "
+                    f"{MAX_RESPONSE_BYTES/1024/1024:.0f}MB 上限"
+                )
+            chunks: list[bytes] = []
+            total = 0
+            async for chunk in r.aiter_bytes():
+                total += len(chunk)
+                if total > MAX_RESPONSE_BYTES:
                     raise ImageSaveError(
-                        f"远端图 Content-Length={int(cl)/1024/1024:.1f}MB 超过 "
-                        f"{MAX_RESPONSE_BYTES/1024/1024:.0f}MB 上限"
+                        f"远端图实际下载 >{MAX_RESPONSE_BYTES/1024/1024:.0f}MB，已中断"
                     )
-                chunks: list[bytes] = []
-                total = 0
-                async for chunk in r.aiter_bytes():
-                    total += len(chunk)
-                    if total > MAX_RESPONSE_BYTES:
-                        raise ImageSaveError(
-                            f"远端图实际下载 >{MAX_RESPONSE_BYTES/1024/1024:.0f}MB，已中断"
-                        )
-                    chunks.append(chunk)
-                raw = b"".join(chunks)
-    except TimeoutError as e:
+                chunks.append(chunk)
+            return b"".join(chunks)
+
+    # 给整段下载加墙钟上限，防慢滴流无限挂起独占大图锁；wait_for 兼容 Python 3.10。
+    try:
+        raw = await asyncio.wait_for(_download_raw(), timeout=_DOWNLOAD_TOTAL_TIMEOUT_SECONDS)
+    except asyncio.TimeoutError as e:
         raise ImageSaveError(
             f"远端图下载超过 {_DOWNLOAD_TOTAL_TIMEOUT_SECONDS:.0f}s 墙钟上限，已中断"
         ) from e

--- a/server.py
+++ b/server.py
@@ -24,6 +24,8 @@ from mcp.server.fastmcp import FastMCP
 from micu_image_mcp.config import (
     _LOCK_BACKEND, _FILE_LOCK_AVAILABLE,
     DEFAULT_BASEURL, API_KEY, DEFAULT_MODEL,
+    API_RESPONSE_FORMAT, TRUSTED_DOWNLOAD_HOSTS, ALLOW_FAKE_IP_DOWNLOAD,
+    RESPONSE_FORMATS_TO_TRY,
     GROK_BASEURL, GROK_API_KEY, XAI_MODEL, GROK_SIZE_MODE,
     _TRUST_ENV, _SAVE_ROOT, DEFAULT_SAVE_DIR,
     PRO_MODEL, NONPRO_MODEL,
@@ -77,7 +79,7 @@ from micu_image_mcp.save import (
     ImageSaveError,
     _normalized_image_bytes_sync, _maybe_normalize_image_bytes,
     _save_validated_bytes, _save_image_b64, _save_image_url,
-    _save_first_payload_from_response,
+    _save_extracted_payload, _save_first_payload_from_response,
 )
 
 
@@ -111,6 +113,61 @@ def _get_baseurl() -> str:
 
 def _get_grok_baseurl() -> str:
     return GROK_BASEURL
+
+
+async def _call_and_save_with_format_fallback(
+    *,
+    build_ep: "Callable[[str], Endpoint]",
+    key: str,
+    retry_pro: bool,
+    stream: bool,
+    big_size_lock: bool,
+    notes: list[str],
+    out_dir: Path,
+    stem: str,
+    requested_size: str,
+    on_http_fallback: "Callable[[], Awaitable[tuple[int, str]]] | None" = None,
+    normalize_size: str | None = None,
+    normalize_mode: str | None = None,
+    normalize_label: str = "图片",
+) -> tuple[dict[str, Any] | None, str | None, bool]:
+    """按 RESPONSE_FORMATS_TO_TRY 顺序调 API 并落盘；默认先 url，保存失败再 b64_json。
+
+    返回 (saved_info, error, used_http_fallback)。
+  on_http_fallback 仅在第一种 format 的 HTTP 失败时触发（如 edits→chat stream）。
+    """
+    last_err: str | None = None
+    used_http_fallback = False
+    for fmt_i, fmt in enumerate(RESPONSE_FORMATS_TO_TRY):
+        if fmt_i > 0:
+            notes.append(f"URL 落盘失败（{last_err}）→ 重试 API response_format={fmt}")
+        ep = build_ep(fmt)
+        status, text = await _call_with_retry(
+            ep, key, retry_pro=retry_pro, stream=stream,
+            big_size_lock=big_size_lock, notes_out=notes,
+        )
+        if not (200 <= status < 300) and fmt_i == 0 and on_http_fallback is not None:
+            status, text = await on_http_fallback()
+            used_http_fallback = True
+        if not (200 <= status < 300):
+            last_err = f"HTTP {status}: {_error_detail(text)}"
+            continue
+        saved_info, save_err = await _save_first_payload_from_response(
+            text,
+            out_dir,
+            stem,
+            notes,
+            requested_size,
+            normalize_size=normalize_size,
+            normalize_mode=normalize_mode,
+            normalize_label=normalize_label,
+        )
+        if saved_info:
+            if fmt_i > 0:
+                notes.append(f"已通过 response_format={fmt} 成功落盘")
+            return saved_info, None, used_http_fallback
+        last_err = save_err or "保存失败"
+    return None, last_err, used_http_fallback
 
 
 @mcp.tool()
@@ -257,86 +314,83 @@ async def image_generate(
                 f"本地归一化到请求 size={size}。"
             )
         aspect_ratio = _grok_aspect_ratio(size)
-        grok_ep = Endpoint(
-            url=f"{baseurl}/v1/images/generations",
-            json_body={
-                "model": eff_model,
-                "prompt": prompt,
-                "n": n,
-                "resolution": _grok_resolution(size),
-                "aspect_ratio": aspect_ratio,
-                "response_format": "url",
-            },
-        )
-        status, text = await _call_with_retry(
-            grok_ep, key, retry_pro=True, stream=False,
-            big_size_lock=False, notes_out=notes,
-        )
-        if not (200 <= status < 300):
-            return {
-                "ok": False,
-                "error": f"HTTP {status}: {_error_detail(text)}",
-                "errors": [f"HTTP {status}: {_error_detail(text)}"],
-                "model": eff_model,
-                "size": size,
-                "requested_n": n,
-                "notes": notes,
-            }
+        last_grok_err: str | None = None
+        for fmt_i, fmt in enumerate(RESPONSE_FORMATS_TO_TRY):
+            if fmt_i > 0:
+                notes.append(f"URL 落盘失败（{last_grok_err}）→ 重试 API response_format={fmt}")
+            grok_ep = Endpoint(
+                url=f"{baseurl}/v1/images/generations",
+                json_body={
+                    "model": eff_model,
+                    "prompt": prompt,
+                    "n": n,
+                    "resolution": _grok_resolution(size),
+                    "aspect_ratio": aspect_ratio,
+                    "response_format": fmt,
+                },
+            )
+            status, text = await _call_with_retry(
+                grok_ep, key, retry_pro=True, stream=False,
+                big_size_lock=False, notes_out=notes,
+            )
+            if not (200 <= status < 300):
+                last_grok_err = f"HTTP {status}: {_error_detail(text)}"
+                continue
 
-        resp = _parse_response(text)
-        payloads = _extract_image_payloads(resp)
-        saved: list[dict[str, Any]] = []
-        errors: list[str] = []
-        for idx, (b64, url) in enumerate(payloads[:n]):
-            try:
-                if b64:
-                    p, actual, size_bytes = await _save_image_b64(
+            resp = _parse_response(text)
+            payloads = _extract_image_payloads(resp)
+            saved: list[dict[str, Any]] = []
+            errors: list[str] = []
+            for idx, (b64, url) in enumerate(payloads[:n]):
+                try:
+                    p, actual, size_bytes = await _save_extracted_payload(
                         b64,
-                        out_dir,
-                        f"{stem}_{idx + 1}",
-                        normalize_size=size,
-                        normalize_mode=size_mode,
-                        notes=notes,
-                        normalize_label="Grok 文生图",
-                    )
-                elif url:
-                    p, actual, size_bytes = await _save_image_url(
                         url,
                         out_dir,
                         f"{stem}_{idx + 1}",
+                        notes,
                         normalize_size=size,
                         normalize_mode=size_mode,
-                        notes=notes,
                         normalize_label="Grok 文生图",
                     )
-                else:
-                    errors.append(f"#{idx + 1} 响应里未找到图片")
+                except Exception as e:  # noqa: BLE001
+                    errors.append(f"#{idx + 1} 保存失败: {e}")
                     continue
-            except Exception as e:  # noqa: BLE001
-                errors.append(f"#{idx + 1} 保存失败: {e}")
-                continue
-            entry: dict[str, Any] = {
-                "index": idx + 1,
-                "path": str(p.resolve()),
-                "size_bytes": size_bytes,
-            }
-            if actual:
-                entry["actual_size"] = f"{actual[0]}x{actual[1]}"
-                entry["actual_megapixels"] = round(actual[0] * actual[1] / 1_000_000, 2)
-                sn = _size_note(size, actual)
-                if sn and sn not in notes:
-                    notes.append(sn)
-            saved.append(entry)
-        if len(payloads) < n:
-            notes.append(f"Grok 仅返回 {len(payloads)} 张（< 请求 n={n}）；以 saved 实际张数为准。")
+                entry: dict[str, Any] = {
+                    "index": idx + 1,
+                    "path": str(p.resolve()),
+                    "size_bytes": size_bytes,
+                }
+                if actual:
+                    entry["actual_size"] = f"{actual[0]}x{actual[1]}"
+                    entry["actual_megapixels"] = round(actual[0] * actual[1] / 1_000_000, 2)
+                    sn = _size_note(size, actual)
+                    if sn and sn not in notes:
+                        notes.append(sn)
+                saved.append(entry)
+            if saved:
+                if fmt_i > 0:
+                    notes.append(f"已通过 response_format={fmt} 成功落盘")
+                if len(payloads) < n:
+                    notes.append(f"Grok 仅返回 {len(payloads)} 张（< 请求 n={n}）；以 saved 实际张数为准。")
+                return {
+                    "ok": True,
+                    "model": eff_model,
+                    "size": size,
+                    "requested_n": n,
+                    "used_fallback": False,
+                    "saved": saved,
+                    "errors": errors,
+                    "notes": notes,
+                }
+            last_grok_err = "; ".join(errors) if errors else "保存失败"
         return {
-            "ok": bool(saved),
+            "ok": False,
+            "error": last_grok_err,
+            "errors": [last_grok_err or "保存失败"],
             "model": eff_model,
             "size": size,
             "requested_n": n,
-            "used_fallback": False,
-            "saved": saved,
-            "errors": errors,
             "notes": notes,
         }
 
@@ -346,17 +400,6 @@ async def image_generate(
     # ≥2K 失败兜底：chat stream（size 不生效，输出 ~1.57MP），见下方 _do_one。
     # 1K 不需要兜底（generations 1K 路径稳定）。
     # CF 524 = origin 处理 >120s，60s 退避大概率仍 524（origin 持续慢），fail fast 直走 fallback。
-    ep = Endpoint(
-        url=f"{baseurl}/v1/images/generations",
-        json_body={
-            "model": eff_model,
-            "prompt": prompt,
-            "n": 1,
-            "size": size,
-            "response_format": "url",
-        },
-    )
-
     saved: list[dict] = []
     errors: list[str] = []
     # 客户端循环 N 次单图请求（米醋 image_generation tool 不接受 n 字段）。
@@ -372,56 +415,76 @@ async def image_generate(
 
     async def _do_one(idx: int) -> tuple[int, dict | None, str | None]:
         nonlocal used_fallback
-        status, text = await _call_with_retry(
-            ep, key, retry_pro=aggressive_retry, stream=False,
-            big_size_lock=big_size_lock, notes_out=notes,
-        )
-        # ≥2K 撞 524（origin t2i+pro+2K 路径间歇死）→ chat stream fallback。
-        # 代价：chat 路径 size 不生效，输出固定 ~1.57MP；但比空手回好（已透明告知）。
-        # 只对服务端/网络错误降级（FALLBACK_STATUS），429/409 配额冲突不降级以免静默产出错分辨率图。
-        if not (200 <= status < 300) and big_size_lock and status in FALLBACK_STATUS:
-            chat_ep = Endpoint(
-                url=f"{baseurl}/v1/chat/completions",
+        last_err: str | None = None
+        for fmt_i, fmt in enumerate(RESPONSE_FORMATS_TO_TRY):
+            if fmt_i > 0:
+                notes.append(f"URL 落盘失败（{last_err}）→ 重试 API response_format={fmt}")
+            ep = Endpoint(
+                url=f"{baseurl}/v1/images/generations",
                 json_body={
                     "model": eff_model,
-                    "messages": [{"role": "user", "content": prompt}],
-                    "size": size,  # 米醋接受但 chat 路径下不生效
+                    "prompt": prompt,
+                    "n": 1,
+                    "size": size,
+                    "response_format": fmt,
                 },
             )
-            # fallback 仍是 ≥2K 请求，必须复用同一把大图锁串行打 origin（否则多窗口并发绕过锁）。
-            chat_status, chat_text = await _call_with_retry(
-                chat_ep, key, retry_pro=is_pro, stream=True,
+            status, text = await _call_with_retry(
+                ep, key, retry_pro=aggressive_retry, stream=False,
                 big_size_lock=big_size_lock, notes_out=notes,
             )
-            if 200 <= chat_status < 300:
-                used_fallback = True
-                fb_note = f"generations 主路径 HTTP {status}（origin {size} 路径今晚拥塞）→ fallback chat stream（size 不生效，实际输出 ~1.57MP）"
-                if fb_note not in notes:
-                    notes.append(fb_note)
-                status, text = chat_status, chat_text
-        if not (200 <= status < 300):
-            return idx, None, f"#{idx + 1} HTTP {status}: {_error_detail(text)}"
-        resp = _parse_response(text)
-        b64, url = _extract_image_payload(resp)
-        try:
-            if b64:
-                p, actual, size_bytes = await _save_image_b64(b64, out_dir, f"{stem}_{idx + 1}")
-            elif url:
-                p, actual, size_bytes = await _save_image_url(url, out_dir, f"{stem}_{idx + 1}")
-            else:
-                excerpt = text[:300] if isinstance(text, str) else str(resp)[:300]
-                return idx, None, f"#{idx + 1} 响应里未找到图片（响应摘要：{excerpt}）"
-        except Exception as e:  # noqa: BLE001
-            return idx, None, f"#{idx + 1} 保存失败: {e}"
-        entry: dict[str, Any] = {
-            "index": idx + 1,
-            "path": str(p.resolve()),
-            "size_bytes": size_bytes,
-        }
-        if actual:
-            entry["actual_size"] = f"{actual[0]}x{actual[1]}"
-            entry["actual_megapixels"] = round(actual[0] * actual[1] / 1_000_000, 2)
-        return idx, entry, None
+            # ≥2K 撞 524 → chat stream fallback（仅第一种 format 的 HTTP 失败时）。
+            if (
+                not (200 <= status < 300)
+                and big_size_lock
+                and status in FALLBACK_STATUS
+                and fmt_i == 0
+            ):
+                chat_ep = Endpoint(
+                    url=f"{baseurl}/v1/chat/completions",
+                    json_body={
+                        "model": eff_model,
+                        "messages": [{"role": "user", "content": prompt}],
+                        "size": size,
+                    },
+                )
+                chat_status, chat_text = await _call_with_retry(
+                    chat_ep, key, retry_pro=is_pro, stream=True,
+                    big_size_lock=big_size_lock, notes_out=notes,
+                )
+                if 200 <= chat_status < 300:
+                    used_fallback = True
+                    fb_note = (
+                        f"generations 主路径 HTTP {status}（origin {size} 路径今晚拥塞）"
+                        "→ fallback chat stream（size 不生效，实际输出 ~1.57MP）"
+                    )
+                    if fb_note not in notes:
+                        notes.append(fb_note)
+                    status, text = chat_status, chat_text
+            if not (200 <= status < 300):
+                last_err = f"#{idx + 1} HTTP {status}: {_error_detail(text)}"
+                continue
+            resp = _parse_response(text)
+            b64, url = _extract_image_payload(resp)
+            try:
+                p, actual, size_bytes = await _save_extracted_payload(
+                    b64, url, out_dir, f"{stem}_{idx + 1}", notes,
+                )
+            except Exception as e:  # noqa: BLE001
+                last_err = f"#{idx + 1} 保存失败: {e}"
+                continue
+            if fmt_i > 0:
+                notes.append(f"已通过 response_format={fmt} 成功落盘")
+            entry: dict[str, Any] = {
+                "index": idx + 1,
+                "path": str(p.resolve()),
+                "size_bytes": size_bytes,
+            }
+            if actual:
+                entry["actual_size"] = f"{actual[0]}x{actual[1]}"
+                entry["actual_megapixels"] = round(actual[0] * actual[1] / 1_000_000, 2)
+            return idx, entry, None
+        return idx, None, last_err or f"#{idx + 1} 保存失败"
 
     if concurrency > 1:
         sem = asyncio.Semaphore(concurrency)
@@ -588,8 +651,8 @@ async def image_edit(
             notes.append("Grok reference_image 路径当前不支持 mask，已忽略 mask_path。")
         img_b64 = await asyncio.to_thread(lambda: base64.b64encode(img_bytes).decode())
         img_data_url = f"data:{img_mime};base64,{img_b64}"
-        status, text = await _call_with_retry(
-            Endpoint(
+        saved_info, save_err, _ = await _call_and_save_with_format_fallback(
+            build_ep=lambda fmt: Endpoint(
                 url=f"{baseurl}/v1/images/generations",
                 json_body={
                     "model": eff_model,
@@ -598,32 +661,17 @@ async def image_edit(
                     "resolution": _grok_resolution(size),
                     "aspect_ratio": _grok_aspect_ratio(size),
                     "reference_image": img_data_url,
-                    "response_format": "url",
+                    "response_format": fmt,
                 },
             ),
-            key,
+            key=key,
             retry_pro=True,
             stream=False,
             big_size_lock=False,
-            notes_out=notes,
-        )
-        if not (200 <= status < 300):
-            msg = f"HTTP {status}: {_error_detail(text)}"
-            return {
-                "ok": False,
-                "model": eff_model,
-                "size": size,
-                "used_fallback": False,
-                "error": msg,
-                "errors": [msg],
-                "notes": notes,
-            }
-        saved_info, save_err = await _save_first_payload_from_response(
-            text,
-            out_dir,
-            stem,
-            notes,
-            size,
+            notes=notes,
+            out_dir=out_dir,
+            stem=stem,
+            requested_size=size,
             normalize_size=size,
             normalize_mode=size_mode,
             normalize_label="Grok 图生图",
@@ -664,19 +712,7 @@ async def image_edit(
     img_data_url = f"data:{img_mime};base64,{img_b64}"
     used_fallback = False
 
-    # 所有尺寸统一走 /v1/images/edits multipart（含 mask）→ 失败 fallback chat stream。
-    # edits 是米醋唯一真正消费输入图的端点（旧 ≥2K generations+reference_image 路径 524 硬失败，已废弃）；
-    # 1K 档稳定 ~1.57MP，2K 档 best-effort 真 2K（pro + edits，约 2/3 成功，524 时 fallback chat → ~1.57MP）。
-    edits_form: dict[str, Any] = {
-        "model": eff_model,
-        "prompt": prompt,
-        "size": size,
-        "response_format": "url",
-        "image": (img_p.name, img_bytes, img_mime),
-    }
-    if mask_bytes:
-        edits_form["mask"] = ("mask.png", mask_bytes, "image/png")
-    edits_ep = Endpoint(url=f"{baseurl}/v1/images/edits", multipart=edits_form)
+    used_fallback = False
 
     # chat fallback：把图嵌成 data URL
     size_directive = (
@@ -706,56 +742,55 @@ async def image_edit(
         json_body={"model": eff_model, "messages": [{"role": "user", "content": chat_content}]},
     )
 
-    # 2K/4K 复用跨进程大图锁串行打 pro 队列（避免多窗口并发绕过锁），并放宽重试
     aggressive_retry = is_pro or _size_tier(size) in ("2k", "4k")
     big_size_lock = _size_tier(size) in ("2k", "4k")
-    status, text = await _call_with_retry(
-        edits_ep, key, retry_pro=aggressive_retry, stream=False,
-        big_size_lock=big_size_lock, notes_out=notes,
-    )
-    # 只对服务端/网络错误 fallback；400/401/403/413/429 等用户/鉴权/配额错误不降级，避免掩盖真因
-    if not (200 <= status < 300) and status in FALLBACK_STATUS:
-        used_fallback = True
-        notes.append(f"edits 端点 HTTP {status}，已切到 /v1/chat/completions stream")
-        # fallback 仍是 ≥2K 请求时复用同一把大图锁串行打 origin
+    last_err: str | None = None
+    saved_info: dict[str, Any] | None = None
+
+    for fmt_i, fmt in enumerate(RESPONSE_FORMATS_TO_TRY):
+        if fmt_i > 0:
+            notes.append(f"URL 落盘失败（{last_err}）→ 重试 API response_format={fmt}")
+        edits_form: dict[str, Any] = {
+            "model": eff_model,
+            "prompt": prompt,
+            "size": size,
+            "response_format": fmt,
+            "image": (img_p.name, img_bytes, img_mime),
+        }
+        if mask_bytes:
+            edits_form["mask"] = ("mask.png", mask_bytes, "image/png")
+        edits_ep = Endpoint(url=f"{baseurl}/v1/images/edits", multipart=edits_form)
         status, text = await _call_with_retry(
-            chat_ep, key, retry_pro=aggressive_retry, stream=True,
+            edits_ep, key, retry_pro=aggressive_retry, stream=False,
             big_size_lock=big_size_lock, notes_out=notes,
         )
+        if not (200 <= status < 300) and status in FALLBACK_STATUS and fmt_i == 0:
+            used_fallback = True
+            notes.append(f"edits 端点 HTTP {status}，已切到 /v1/chat/completions stream")
+            status, text = await _call_with_retry(
+                chat_ep, key, retry_pro=aggressive_retry, stream=True,
+                big_size_lock=big_size_lock, notes_out=notes,
+            )
+        if not (200 <= status < 300):
+            last_err = f"HTTP {status}: {_error_detail(text)}"
+            continue
+        saved_info, save_err = await _save_first_payload_from_response(
+            text, out_dir, stem, notes, size,
+        )
+        if saved_info:
+            if fmt_i > 0:
+                notes.append(f"已通过 response_format={fmt} 成功落盘")
+            break
+        last_err = save_err or "保存失败"
 
-    if not (200 <= status < 300):
+    if not saved_info:
         return {
             "ok": False,
             "model": eff_model,
             "size": size,
-            "error": f"HTTP {status}: {_error_detail(text)}",
+            "error": last_err or "保存失败",
             "notes": notes,
         }
-
-    resp = _parse_response(text)
-    b64, url = _extract_image_payload(resp)
-    try:
-        if b64:
-            p, actual, size_bytes = await _save_image_b64(b64, out_dir, stem)
-        elif url:
-            p, actual, size_bytes = await _save_image_url(url, out_dir, stem)
-        else:
-            return {
-                "ok": False,
-                "error": "响应中未识别到图片",
-                "raw_excerpt": (text[:500] if isinstance(text, str) else str(resp)[:500]),
-                "notes": notes,
-            }
-    except Exception as e:  # noqa: BLE001
-        return {"ok": False, "error": f"保存失败: {e}", "notes": notes}
-
-    saved_info: dict[str, Any] = {"path": str(p.resolve()), "size_bytes": size_bytes}
-    if actual:
-        saved_info["actual_size"] = f"{actual[0]}x{actual[1]}"
-        saved_info["actual_megapixels"] = round(actual[0] * actual[1] / 1_000_000, 2)
-        sn = _size_note(size, actual)
-        if sn and sn not in notes:
-            notes.append(sn)
 
     return {
         "ok": True,
@@ -1051,8 +1086,8 @@ async def image_multi_reference(
             "Do NOT collage, tile, or montage the references side-by-side unless explicitly asked.\n\n"
             f"Instruction:\n{prompt}"
         )
-        status, text = await _call_with_retry(
-            Endpoint(
+        saved_info, save_err, _ = await _call_and_save_with_format_fallback(
+            build_ep=lambda fmt: Endpoint(
                 url=f"{baseurl}/v1/images/generations",
                 json_body={
                     "model": eff_model,
@@ -1061,39 +1096,31 @@ async def image_multi_reference(
                     "resolution": _grok_resolution(size),
                     "aspect_ratio": _grok_aspect_ratio(size),
                     "image_urls": image_urls,
-                    "response_format": "url",
+                    "response_format": fmt,
                 },
             ),
-            key,
+            key=key,
             retry_pro=True,
             stream=False,
             big_size_lock=False,
-            notes_out=notes,
-        )
-        if not (200 <= status < 300):
-            msg = f"HTTP {status}: {_error_detail(text)}"
-            return {
-                "ok": False,
-                "model": eff_model,
-                "size": size,
-                "n_references": len(image_paths),
-                "used_fallback": False,
-                "error": msg,
-                "errors": [msg],
-                "notes": notes,
-            }
-        saved_info, save_err = await _save_first_payload_from_response(
-            text,
-            out_dir,
-            stem,
-            notes,
-            size,
+            notes=notes,
+            out_dir=out_dir,
+            stem=stem,
+            requested_size=size,
             normalize_size=size,
             normalize_mode=size_mode,
             normalize_label="Grok 多图参考",
         )
         if save_err:
-            return {"ok": False, "model": eff_model, "size": size, "error": save_err, "errors": [save_err], "notes": notes}
+            return {
+                "ok": False,
+                "model": eff_model,
+                "size": size,
+                "n_references": len(image_paths),
+                "error": save_err,
+                "errors": [save_err],
+                "notes": notes,
+            }
         return {
             "ok": True,
             "model": eff_model,
@@ -1145,86 +1172,77 @@ async def image_multi_reference(
         f"Do NOT collage, tile, or montage the references side-by-side unless explicitly asked.\n\n"
         f"Instruction:\n{prompt}"
     )
-    edits_ep = Endpoint(
-        url=f"{baseurl}/v1/images/edits",
-        multipart={
+    chat_ep = Endpoint(
+        url=f"{baseurl}/v1/chat/completions",
+        json_body={
             "model": eff_model,
-            "prompt": full_prompt,
+            "messages": [{"role": "user", "content": full_prompt}],
+            "image_urls": image_urls,
             "size": size,
-            "response_format": "url",
-            "image[]": ref_files,
         },
     )
 
     aggressive_retry = is_pro or _size_tier(size) in ("2k", "4k")
     big_size_lock = _size_tier(size) in ("2k", "4k")
-    status, text = await _call_with_retry(
-        edits_ep, key, retry_pro=aggressive_retry, stream=False,
-        big_size_lock=big_size_lock, notes_out=notes,
-    )
-
     used_fallback = False
-    # 只对服务端/网络错误 fallback；400/401/403/413/429 等用户/配额错误直接返回，避免掩盖真因
-    if not (200 <= status < 300) and status in FALLBACK_STATUS:
-        # generations 失败 → 走 chat stream 兜底
-        notes.append(f"edits 主路径 HTTP {status}（米醋多图间歇拒/断流），已 fallback chat stream（size 不生效，输出 ~1.57MP）")
-        used_fallback = True
-        chat_ep = Endpoint(
-            url=f"{baseurl}/v1/chat/completions",
-            json_body={
+    last_err: str | None = None
+    saved_info: dict[str, Any] | None = None
+
+    for fmt_i, fmt in enumerate(RESPONSE_FORMATS_TO_TRY):
+        if fmt_i > 0:
+            notes.append(f"URL 落盘失败（{last_err}）→ 重试 API response_format={fmt}")
+        edits_ep = Endpoint(
+            url=f"{baseurl}/v1/images/edits",
+            multipart={
                 "model": eff_model,
-                "messages": [{"role": "user", "content": full_prompt}],
-                "image_urls": image_urls,
-                "size": size,  # 米醋接受但 chat 路径下不生效
+                "prompt": full_prompt,
+                "size": size,
+                "response_format": fmt,
+                "image[]": ref_files,
             },
         )
-        # fallback 仍是 ≥2K 请求时复用同一把大图锁串行打 origin（否则多窗口并发绕过锁）。
         status, text = await _call_with_retry(
-            chat_ep, key, retry_pro=is_pro, stream=True,
+            edits_ep, key, retry_pro=aggressive_retry, stream=False,
             big_size_lock=big_size_lock, notes_out=notes,
         )
+        if not (200 <= status < 300) and status in FALLBACK_STATUS and fmt_i == 0:
+            notes.append(
+                f"edits 主路径 HTTP {status}（米醋多图间歇拒/断流），"
+                "已 fallback chat stream（size 不生效，输出 ~1.57MP）"
+            )
+            used_fallback = True
+            status, text = await _call_with_retry(
+                chat_ep, key, retry_pro=is_pro, stream=True,
+                big_size_lock=big_size_lock, notes_out=notes,
+            )
+        if not (200 <= status < 300):
+            last_err = f"HTTP {status}: {_error_detail(text)}"
+            continue
+        saved_info, save_err = await _save_first_payload_from_response(
+            text, out_dir, stem, notes, size,
+        )
+        if saved_info:
+            if fmt_i > 0:
+                notes.append(f"已通过 response_format={fmt} 成功落盘")
+            break
+        last_err = save_err or "保存失败"
 
-    if not (200 <= status < 300):
+    if not saved_info:
         return {
             "ok": False,
             "model": eff_model,
             "n_references": len(image_paths),
             "used_fallback": used_fallback,
-            "error": f"HTTP {status}: {_error_detail(text)}",
+            "error": last_err or "保存失败",
             "notes": notes,
         }
 
-    resp = _parse_response(text)
-    b64, url = _extract_image_payload(resp)
-    try:
-        if b64:
-            p, actual, size_bytes = await _save_image_b64(b64, out_dir, stem)
-        elif url:
-            p, actual, size_bytes = await _save_image_url(url, out_dir, stem)
-        else:
-            return {
-                "ok": False,
-                "error": "响应中未识别到图片",
-                "raw_excerpt": text[:500] if isinstance(text, str) else str(resp)[:500],
-                "notes": notes,
-            }
-    except Exception as e:  # noqa: BLE001
-        return {"ok": False, "error": f"保存失败: {e}", "notes": notes}
-
-    saved_info: dict[str, Any] = {"path": str(p.resolve()), "size_bytes": size_bytes}
-    if actual:
-        saved_info["actual_size"] = f"{actual[0]}x{actual[1]}"
-        saved_info["actual_megapixels"] = round(actual[0] * actual[1] / 1_000_000, 2)
-        sn = _size_note(size, actual)
-        if sn and sn not in notes:
-            notes.append(sn)
-
+    actual = _parse_actual(saved_info.get("actual_size"))
     return {
         "ok": True,
         "model": eff_model,
         "size": size,
         "used_fallback": used_fallback,
-        # 按实际像素如实判定是否命中请求 size（2K 成功时 actual==requested → true）；真实像素见 saved.actual_size
         "size_honored": bool(actual and _parse_size(size) and actual == _parse_size(size)),
         "n_references": len(image_paths),
         "saved": saved_info,
@@ -1254,6 +1272,10 @@ def server_info() -> dict[str, Any]:
         "default_save_dir": str(DEFAULT_SAVE_DIR),
         "api_key_configured": bool(API_KEY),
         "grok_api_key_configured": bool(GROK_API_KEY),
+        "response_format": API_RESPONSE_FORMAT,
+        "response_formats_to_try": list(RESPONSE_FORMATS_TO_TRY),
+        "trusted_download_hosts": sorted(TRUSTED_DOWNLOAD_HOSTS),
+        "allow_fake_ip_download": ALLOW_FAKE_IP_DOWNLOAD,
         "size_rules": {
             "format": "WxH 字符串（如 '1024x1024'）",
             "alignment": f"W 与 H 都必须是 {SIZE_ALIGNMENT} 的整数倍（米醋实测约束，OpenAI 官方要 16）",

--- a/tests/unit/test_locks.py
+++ b/tests/unit/test_locks.py
@@ -27,9 +27,10 @@ def test_lock_cancel_during_wait_does_not_deadlock():
             with pytest.raises(asyncio.CancelledError):
                 await t
         # 外层退出释放锁后，再次获取必须能在合理时间内拿到（无死锁/无孤儿持锁）。
-        async with asyncio.timeout(5):
+        async def acquire_once() -> bool:
             async with locks._big_size_file_lock_async():
                 return True
-        return False
+
+        return await asyncio.wait_for(acquire_once(), timeout=5)
 
     assert asyncio.run(scenario()) is True

--- a/tests/unit/test_ssrf.py
+++ b/tests/unit/test_ssrf.py
@@ -82,6 +82,70 @@ def test_allow_hostname_resolving_to_public(monkeypatch):
     _assert_download_url_safe("https://oss.filenest.top/uploads/x.png")
 
 
+def test_allow_trusted_hostname_fake_ip(monkeypatch):
+    """Clash/Surge fake-ip：可信 CDN 域名解析到 198.18.x.x 应放行。"""
+    def fake_getaddrinfo(host, port, *a, **k):
+        return [(2, 1, 6, "", ("198.18.1.23", port or 443))]
+    monkeypatch.setattr(save.socket, "getaddrinfo", fake_getaddrinfo)
+    monkeypatch.setattr(save, "ALLOW_FAKE_IP_DOWNLOAD", True)
+    _assert_download_url_safe("https://oss.filenest.top/uploads/x.png")
+
+
+def test_block_trusted_hostname_resolving_to_true_private(monkeypatch):
+    """可信域名若解析到真内网仍拒绝（防 DNS 投毒）。"""
+    def fake_getaddrinfo(host, port, *a, **k):
+        return [(2, 1, 6, "", ("10.1.2.3", port or 443))]
+    monkeypatch.setattr(save.socket, "getaddrinfo", fake_getaddrinfo)
+    monkeypatch.setattr(save, "ALLOW_FAKE_IP_DOWNLOAD", True)
+    with pytest.raises(ImageSaveError):
+        _assert_download_url_safe("https://oss.filenest.top/uploads/x.png")
+
+
+def test_block_untrusted_hostname_fake_ip(monkeypatch):
+    def fake_getaddrinfo(host, port, *a, **k):
+        return [(2, 1, 6, "", ("198.18.1.23", port or 443))]
+    monkeypatch.setattr(save.socket, "getaddrinfo", fake_getaddrinfo)
+    monkeypatch.setattr(save, "ALLOW_FAKE_IP_DOWNLOAD", True)
+    with pytest.raises(ImageSaveError):
+        _assert_download_url_safe("https://images.evil.example/x.png")
+
+
+def test_block_fake_ip_when_disabled(monkeypatch):
+    def fake_getaddrinfo(host, port, *a, **k):
+        return [(2, 1, 6, "", ("198.18.1.23", port or 443))]
+    monkeypatch.setattr(save.socket, "getaddrinfo", fake_getaddrinfo)
+    monkeypatch.setattr(save, "ALLOW_FAKE_IP_DOWNLOAD", False)
+    with pytest.raises(ImageSaveError):
+        _assert_download_url_safe("https://oss.filenest.top/uploads/x.png")
+
+
+def test_save_image_url_fake_ip_trusted_host(monkeypatch, tmp_path):
+    """端到端：fake-ip 地址下载可信 CDN URL 能落盘。"""
+    png = _png_bytes()
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, content=png, headers={"content-length": str(len(png))})
+
+    client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    monkeypatch.setattr(http_client, "_HTTP_CLIENT", client)
+    monkeypatch.setattr(save, "ALLOW_FAKE_IP_DOWNLOAD", True)
+
+    def fake_getaddrinfo(host, port, *a, **k):
+        return [(2, 1, 6, "", ("198.18.1.23", port or 443))]
+
+    monkeypatch.setattr(save.socket, "getaddrinfo", fake_getaddrinfo)
+
+    save_dir = config._SAVE_ROOT / "ssrf_fake_ip"
+    save_dir.mkdir(parents=True, exist_ok=True)
+
+    p, actual, size_bytes = asyncio.run(
+        save._save_image_url("https://oss.filenest.top/img.png", save_dir, "fakeip")
+    )
+    assert p.exists()
+    assert actual == (32, 32)
+    asyncio.run(client.aclose())
+
+
 # ---------- _save_image_url 端到端（now-primary 路径） ----------
 
 def test_save_image_url_downloads_and_writes(monkeypatch, tmp_path):

--- a/tests/unit/test_tools.py
+++ b/tests/unit/test_tools.py
@@ -87,6 +87,44 @@ def test_image_generate_happy_path(fake_http):
     assert r["saved"], r
 
 
+def test_image_generate_uses_url_first_response_format(monkeypatch):
+    """auto 模式默认先请求 response_format=url。"""
+    captured: dict = {}
+
+    async def fake_call(ep, key, *args, **kwargs):  # noqa: ANN001
+        if ep.json_body:
+            captured.update(ep.json_body)
+        return 200, _canned_b64_response()
+
+    monkeypatch.setattr(server, "_call_with_retry", fake_call)
+    monkeypatch.setattr(server, "RESPONSE_FORMATS_TO_TRY", ("url", "b64_json"))
+    r = asyncio.run(server.image_generate(prompt="test", size="1024x1024", api_key="sk-test"))
+    assert r["ok"] is True, r
+    assert captured.get("response_format") == "url"
+
+
+def test_save_extracted_payload_url_then_b64(monkeypatch, tmp_path):
+    """同响应含 url+b64 时：url 失败应 fallback 到 b64。"""
+    from micu_image_mcp import config
+
+    png = _png_bytes()
+    b64 = base64.b64encode(png).decode()
+    save_dir = config._SAVE_ROOT / "url_b64_fb"
+    save_dir.mkdir(parents=True, exist_ok=True)
+
+    async def failing_url(*_a, **_k):
+        raise save.ImageSaveError("url fail")
+
+    monkeypatch.setattr(save, "_save_image_url", failing_url)
+    notes: list[str] = []
+    p, actual, size_bytes = asyncio.run(
+        save._save_extracted_payload(b64, "https://example.com/x.png", save_dir, "t", notes)
+    )
+    assert p.exists()
+    assert size_bytes == len(png)
+    assert any("b64_json" in n for n in notes)
+
+
 # ---------- M7 子项：推断尺寸越界不再硬错，回退默认 ----------
 
 @pytest.mark.parametrize("prompt", ["a 128x128 icon", "make a 100x100 thumbnail"])


### PR DESCRIPTION
## 问题

在 Clash / Surge 等 **fake-ip** 环境下，米醋 API 返回 CDN URL（`oss.filenest.top`）后，
MCP 下载落盘被 SSRF 防护拒绝（`198.18.x.x` 被判定为私网/保留地址），导致 `image_generate` 等工具 `ok: false`。

## 解决方案

1. **落盘策略**（`MICU_RESPONSE_FORMAT=auto`，默认）：先请求 `url` 并下载落盘；保存失败再重试 API `response_format=b64_json`
2. **SSRF 放宽**：可信 CDN 主机（默认 `oss.filenest.top`）解析到 `198.18.0.0/15` 时允许下载；真内网（10.x 等）仍拒绝
3. **Py3.14 兼容**：fake-ip 判断置于 `is_private` 之前（3.14 将 198.18.x.x 标为 private）

## 文档

- 新增 [`docs/MCP使用教程.md`](docs/MCP使用教程.md)：工具说明、尺寸规则、环境变量、故障排查
- README 增加教程链接

## 变更文件

- `micu_image_mcp/config.py` — 新环境变量与 `RESPONSE_FORMATS_TO_TRY`
- `micu_image_mcp/save.py` — `_save_extracted_payload`、fake-ip 感知 SSRF
- `server.py` — 全工具 url→b64 重试、`server_info` 暴露新配置
- `.env.example` — 文档化新变量
- `tests/unit/test_ssrf.py`、`tests/unit/test_tools.py` — 回归测试

## Test plan

- [x] `pytest tests/unit/test_ssrf.py tests/unit/test_tools.py` — 41 passed
- [x] `python tests/smoke_local.py --entry` — 通过
- [x] 实机 `image_generate` 1024x1024 — `ok: true`，落盘 `/home/wcx/Pictures/micu-out/live_verify_apple_1.png`

Made with [Cursor](https://cursor.com)