### PR TITLE
[codex] 兼容新线路限流与 data URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,8 @@
 
 ---
 
+> **2026-07 线路兼容更新**：支持将限流包装为 `HTTP 400 + Too Many Requests` 的新线路行为，并按 429 语义自动重试；同时兼容 `response_format=url` 返回 `data:image/...;base64,...`。实测 `https://www.micuapi.ai` 经 Cloudflare LAX + Caddy 正常，1K 可用；4K/pro 队列仍可能受上游限流，因此仅保留纯文生图 4K，参考图 4K 暂不放开。
+
 ## 一键安装
 
 方式一：用 Git 下载源码（推荐）。

--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@
 
 > **2026-07 线路兼容更新**：支持将限流包装为 `HTTP 400 + Too Many Requests` 的新线路行为，并按 429 语义自动重试；同时兼容 `response_format=url` 返回 `data:image/...;base64,...`。实测 `https://www.micuapi.ai` 经 Cloudflare LAX + Caddy 正常，1K 可用；4K/pro 队列仍可能受上游限流，因此仅保留纯文生图 4K，参考图 4K 暂不放开。
 
+> **Windows 中文提示词**：MCP 会以原生 UTF-8 JSON 发送中文。自行编写 PowerShell 测试脚本时，不要把含中文的 here-string 直接通过管道喂给 `python -`；Windows PowerShell 的 `$OutputEncoding` 可能是 ASCII，导致中文在进入 MCP 前已变成 `?`。请将脚本保存为 UTF-8 文件后执行，或先设置 `$OutputEncoding = [Console]::OutputEncoding = [System.Text.UTF8Encoding]::new()`。
+
 ## 一键安装
 
 方式一：用 Git 下载源码（推荐）。

--- a/micu_image_mcp/extract.py
+++ b/micu_image_mcp/extract.py
@@ -38,7 +38,11 @@ def _extract_image_payload(resp: dict | str) -> tuple[str | None, str | None]:
             if item.get("b64_json"):
                 return item["b64_json"], None
             if item.get("url"):
-                return None, item["url"]
+                url = str(item["url"])
+                m = re.fullmatch(r"data:image/[^;]+;base64,([A-Za-z0-9+/=\s]+)", url)
+                if m:
+                    return m.group(1).strip(), None
+                return None, url
     # /v1/chat/completions fallback：图嵌在 markdown ![](url) 或 base64
     choices = resp.get("choices") if isinstance(resp, dict) else None
     if isinstance(choices, list) and choices:
@@ -70,7 +74,9 @@ def _extract_image_payloads(resp: dict | str) -> list[tuple[str | None, str | No
             if item.get("b64_json"):
                 payloads.append((str(item["b64_json"]), None))
             elif item.get("url"):
-                payloads.append((None, str(item["url"])))
+                url = str(item["url"])
+                m = re.fullmatch(r"data:image/[^;]+;base64,([A-Za-z0-9+/=\s]+)", url)
+                payloads.append((m.group(1).strip(), None) if m else (None, url))
         if payloads:
             return payloads
     b64, url = _extract_image_payload(resp)

--- a/micu_image_mcp/http_client.py
+++ b/micu_image_mcp/http_client.py
@@ -43,6 +43,11 @@ class Endpoint:
 _HTTP_CLIENT: httpx.AsyncClient | None = None
 
 
+def _json_request_bytes(body: dict | None) -> bytes:
+    """Serialize JSON as literal UTF-8 instead of ASCII-only Unicode escapes."""
+    return json.dumps(body, ensure_ascii=False, separators=(",", ":")).encode("utf-8")
+
+
 def _get_http_client() -> httpx.AsyncClient:
     """返回模块级共享 client；首次调用时创建。
 
@@ -98,8 +103,8 @@ async def _call_endpoint(ep: Endpoint, key: str, timeout: float = 600.0) -> tupl
                 data[k] = v
         ctx = cx.stream("POST", ep.url, headers=headers, data=data, files=files, timeout=timeout)
     else:
-        headers["Content-Type"] = "application/json"
-        ctx = cx.stream("POST", ep.url, headers=headers, content=json.dumps(ep.json_body), timeout=timeout)
+        headers["Content-Type"] = "application/json; charset=utf-8"
+        ctx = cx.stream("POST", ep.url, headers=headers, content=_json_request_bytes(ep.json_body), timeout=timeout)
     async with ctx as r:
         resp_headers = {k.lower(): v for k, v in r.headers.items()}
         cl = resp_headers.get("content-length")
@@ -130,7 +135,7 @@ async def _call_endpoint_stream(ep: Endpoint, key: str, timeout: float = 600.0) 
     headers = {
         "Authorization": f"Bearer {key}",
         "Accept": "text/event-stream",
-        "Content-Type": "application/json",
+        "Content-Type": "application/json; charset=utf-8",
     }
     full_content = ""
     line_count = 0
@@ -141,7 +146,7 @@ async def _call_endpoint_stream(ep: Endpoint, key: str, timeout: float = 600.0) 
     cx = _get_http_client()
     response_headers: dict[str, str] = {}
     try:
-        async with cx.stream("POST", ep.url, headers=headers, content=json.dumps(body), timeout=timeout) as r:
+        async with cx.stream("POST", ep.url, headers=headers, content=_json_request_bytes(body), timeout=timeout) as r:
             final_status = r.status_code
             response_headers = {k.lower(): v for k, v in r.headers.items()}
             if not (200 <= r.status_code < 300):
@@ -355,6 +360,7 @@ async def _call_with_retry(
 
 __all__ = [
     "Endpoint",
+    "_json_request_bytes",
     "_get_http_client",
     "_call_endpoint", "_call_endpoint_stream",
     "_parse_retry_after", "_effective_retry_status",

--- a/micu_image_mcp/http_client.py
+++ b/micu_image_mcp/http_client.py
@@ -213,6 +213,20 @@ def _parse_retry_after(headers: dict[str, str]) -> float | None:
     return min(seconds, MAX_RETRY_AFTER_SECONDS)
 
 
+def _effective_retry_status(status: int, text: str) -> int:
+    """Normalize proxy errors that carry retry semantics under the wrong HTTP code."""
+    if status == 400:
+        detail = _error_detail(text).strip().lower()
+        if any(marker in detail for marker in (
+            "too many requests",
+            "rate limit",
+            "rate_limit",
+            "ratelimit",
+        )):
+            return 429
+    return status
+
+
 def _retry_delay(
     status: int,
     headers: dict[str, str],
@@ -309,8 +323,9 @@ async def _call_with_retry(
 
         retry_attempt = 0
         while not (200 <= status < 300):
+            retry_status = _effective_retry_status(status, text)
             delay = _retry_delay(
-                status,
+                retry_status,
                 headers,
                 attempt_index=retry_attempt,
                 big_size_lock=big_size_lock,
@@ -319,7 +334,7 @@ async def _call_with_retry(
                 break
             _append_retry_note(
                 notes_out,
-                status=status,
+                status=retry_status,
                 delay=delay,
                 next_attempt=attempt_number + 1,
                 text=text,
@@ -342,6 +357,7 @@ __all__ = [
     "Endpoint",
     "_get_http_client",
     "_call_endpoint", "_call_endpoint_stream",
-    "_parse_retry_after", "_retry_delay", "_append_retry_note",
+    "_parse_retry_after", "_effective_retry_status",
+    "_retry_delay", "_append_retry_note",
     "_call_with_retry",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 description = "MCP server for 米醋 (micuapi.ai) gpt-image-2 / gpt-image-2-pro"
 requires-python = ">=3.10"
 dependencies = [
-    "mcp[cli]>=1.0.0",
+    "mcp[cli]>=1.28.1,<2.0.0",
     "httpx>=0.27.0",
     "Pillow>=10.0.0",
 ]

--- a/server.py
+++ b/server.py
@@ -72,8 +72,8 @@ from micu_image_mcp.http_client import (
     Endpoint,
     _get_http_client,
     _call_endpoint, _call_endpoint_stream,
-    _parse_retry_after, _retry_delay, _append_retry_note,
-    _call_with_retry,
+    _parse_retry_after, _effective_retry_status,
+    _retry_delay, _append_retry_note, _call_with_retry,
 )
 from micu_image_mcp.save import (
     ImageSaveError,
@@ -151,7 +151,7 @@ async def _call_and_save_with_format_fallback(
             used_http_fallback = True
         if not (200 <= status < 300):
             last_err = f"HTTP {status}: {_error_detail(text)}"
-            continue
+            break
         saved_info, save_err = await _save_first_payload_from_response(
             text,
             out_dir,
@@ -341,7 +341,7 @@ async def image_generate(
             )
             if not (200 <= status < 300):
                 last_grok_err = f"HTTP {status}: {_error_detail(text)}"
-                continue
+                break
 
             resp = _parse_response(text)
             payloads = _extract_image_payloads(resp)
@@ -471,7 +471,7 @@ async def image_generate(
                     status, text = chat_status, chat_text
             if not (200 <= status < 300):
                 last_err = f"#{idx + 1} HTTP {status}: {_error_detail(text)}"
-                continue
+                break
             resp = _parse_response(text)
             b64, url = _extract_image_payload(resp)
             try:
@@ -781,7 +781,7 @@ async def image_edit(
             )
         if not (200 <= status < 300):
             last_err = f"HTTP {status}: {_error_detail(text)}"
-            continue
+            break
         saved_info, save_err = await _save_first_payload_from_response(
             text, out_dir, stem, notes, size,
         )
@@ -1225,7 +1225,7 @@ async def image_multi_reference(
             )
         if not (200 <= status < 300):
             last_err = f"HTTP {status}: {_error_detail(text)}"
-            continue
+            break
         saved_info, save_err = await _save_first_payload_from_response(
             text, out_dir, stem, notes, size,
         )

--- a/server.py
+++ b/server.py
@@ -70,6 +70,7 @@ from micu_image_mcp.extract import (
 )
 from micu_image_mcp.http_client import (
     Endpoint,
+    _json_request_bytes,
     _get_http_client,
     _call_endpoint, _call_endpoint_stream,
     _parse_retry_after, _effective_retry_status,

--- a/tests/smoke_local.py
+++ b/tests/smoke_local.py
@@ -35,11 +35,11 @@ sys.path.insert(0, str(REPO))
 
 
 def ok(msg: str) -> None:
-    print(f"  \033[32m✓\033[0m {msg}")
+    print(f"  \033[32mOK\033[0m {msg}")
 
 
 def fail(msg: str) -> None:
-    print(f"  \033[31m✗\033[0m {msg}")
+    print(f"  \033[31mFAIL\033[0m {msg}")
     raise SystemExit(1)
 
 

--- a/tests/unit/test_retry.py
+++ b/tests/unit/test_retry.py
@@ -104,6 +104,22 @@ class TestRetryDelay:
         assert delay is not None
 
 
+class TestEffectiveRetryStatus:
+    @pytest.mark.parametrize("message", [
+        "Too Many Requests",
+        "rate limit exceeded",
+        "rate_limit_exceeded",
+    ])
+    def test_proxy_400_rate_limit_is_normalized(self, message):
+        import json
+        text = json.dumps({"error": {"message": message}})
+        assert S._effective_retry_status(400, text) == 429
+
+    def test_regular_400_remains_non_retryable(self):
+        text = '{"error":{"message":"invalid size"}}'
+        assert S._effective_retry_status(400, text) == 400
+
+
 # ---------- _parse_response ----------
 
 class TestParseResponse:
@@ -167,6 +183,11 @@ class TestExtractImagePayload:
         assert b64 is None
         assert url == "https://x.com/y.png"
 
+    def test_data_url_in_data_is_unwrapped(self):
+        b64, url = S._extract_image_payload({"data": [{"url": "data:image/png;base64,AAAABBBB"}]})
+        assert b64 == "AAAABBBB"
+        assert url is None
+
     def test_chat_markdown_url(self):
         resp = {
             "choices": [{"message": {"content": "Here you go ![img](https://x.com/y.png)"}}]
@@ -208,6 +229,10 @@ class TestExtractImagePayloads:
         assert payloads[0] == ("A", None)
         assert payloads[1] == ("B", None)
         assert payloads[2] == (None, "u.png")
+
+    def test_multi_data_url_is_unwrapped(self):
+        payloads = S._extract_image_payloads({"data": [{"url": "data:image/webp;base64,CCCC"}]})
+        assert payloads == [("CCCC", None)]
 
     def test_single_chat_fallback(self):
         # 没 data，走 chat fallback → 返回单元素 list

--- a/tests/unit/test_tools.py
+++ b/tests/unit/test_tools.py
@@ -191,6 +191,27 @@ def test_call_endpoint_normal(monkeypatch):
     asyncio.run(client.aclose())
 
 
+def test_call_endpoint_sends_literal_utf8_json(monkeypatch):
+    prompt = "一只可爱的小猫正在跳伞"
+
+    def handler(request):
+        assert request.headers["content-type"] == "application/json; charset=utf-8"
+        assert prompt.encode("utf-8") in request.content
+        assert b"\\u4e00" not in request.content
+        assert json.loads(request.content.decode("utf-8"))["prompt"] == prompt
+        return httpx.Response(200, json={"data": [{"b64_json": "abc"}]})
+
+    client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    monkeypatch.setattr(http_client, "_HTTP_CLIENT", client)
+    ep = http_client.Endpoint(
+        url="https://x.test/v1/images/generations",
+        json_body={"prompt": prompt},
+    )
+    status, _, _ = asyncio.run(http_client._call_endpoint(ep, "k"))
+    assert status == 200
+    asyncio.run(client.aclose())
+
+
 def test_call_endpoint_rejects_oversized_body(monkeypatch):
     monkeypatch.setattr(http_client, "MAX_RESPONSE_BYTES", 10)
 


### PR DESCRIPTION
﻿## What changed

- normalize proxy-wrapped `HTTP 400 + Too Many Requests` responses to retry as 429
- accept `data:image/...;base64,...` payloads returned in the `url` field
- stop redundant outer response-format retries after the inner retry policy is exhausted
- update the MCP dependency floor to 1.28.1 and document the current line behavior
- make the local smoke test output compatible with Windows GBK terminals

## Why

The current MICU route can expose upstream rate limits as HTTP 400 and can return a base64 data URL even when `response_format=url` is requested. Without normalization, the MCP stops retrying or attempts to download the data URL as a remote URL.

## Validation

- `python -m pytest -q` — 258 passed
- `python tests/smoke_local.py` — MCP stdio initialize, tools/list, server_info, and validation smoke passed
- `python tests/perf_bench.py --full --repeat 2 --dry-run` — 22-case dry-run completed
- `python -m build` — sdist and wheel built successfully
- fresh Python 3.10 virtualenv with latest compatible dependencies, including `mcp 1.28.1`
- real MCP stdio calls passed for all 5 exposed tools: `server_info`, `image_generate` (`n=2`, `quality=low`), `image_edit`, `image_batch_edit`, and `image_multi_reference`
- real API requests returned HTTP 200 and saved 6 output images

## Impact

MICU image generation and editing remain compatible with the latest observed route behavior, with more reliable rate-limit recovery and correct handling of inline base64 image responses.
