### PR TITLE
fix: install.py 在 PEP 668 系统 Python 上自动改用 .venv

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,8 +110,21 @@ MICU_SAVE_DIR="$HOME/Pictures/micu-out" \
 python install.py --yes --runtime python
 ```
 
+Arch / Debian / Fedora 等发行版把系统 Python 标记为 `externally-managed`（PEP 668），
+直接 `pip install` 会失败。`--runtime python` 时 installer 会自动改用仓库内 `.venv`：
+已存在就复用，不存在就创建（优先 `python -m venv`，失败退回 `uv venv --seed`，
+venv 内没有 pip 再退回 `uv pip install --python`），依赖装进 venv，写进 Claude/Codex
+配置的 `command` 与自检用的也是 venv 里的 python。已经在 venv/conda 里跑，或系统
+Python 没被发行版锁住时，行为与之前一致。
+
+```bash
+python install.py --venv-dir ~/venvs/micu     # 虚拟环境放别处
+python install.py --break-system-packages     # 坚持装进系统 Python（有风险）
+```
+
 main 中的 `install.py` 只作为兼容/回滚工具；新安装应使用 Rust binary 自带的 `install`。
 Python installer 会备份并合并 Claude/Codex 配置，`--reset` 只删除 `micu-image` 节。
+`--runtime rust` 不装 Python 依赖，也不会创建 `.venv`。
 
 ### macOS Keychain
 

--- a/docs/migration-from-python.md
+++ b/docs/migration-from-python.md
@@ -27,6 +27,11 @@ release workflow 产出：
 python install.py --runtime python
 ```
 
+Python 模式下，如果系统 Python 被发行版标记为 externally-managed（PEP 668，Arch/Debian/Fedora
+等），脚本会改用仓库内 `.venv`（已存在则复用，否则 `python -m venv` 创建，失败退回
+`uv venv --seed`），依赖装进 venv，写入配置的 `command` 与自检也用 venv 的 python。位置可用
+`--venv-dir` 指定；`--break-system-packages` 则跳过 venv 硬装进系统 Python（有风险）。
+
 试用已有 Rust binary：
 
 ```bash
@@ -188,8 +193,8 @@ MICU_SAVE_DIR="$HOME/Pictures/micu-out" \
 python install.py --yes --runtime python
 ```
 
-该命令会再次备份当前配置，然后只把 `micu-image` command 改回当前 Python + `server.py`；其他
-MCP server 不动。
+该命令会再次备份当前配置，然后只把 `micu-image` command 改回 Python + `server.py`（系统 Python
+受 PEP 668 保护时是 `.venv/bin/python`，否则是运行 installer 的那个 Python）；其他 MCP server 不动。
 
 ### 完全移除 micu-image 节
 

--- a/install.py
+++ b/install.py
@@ -9,6 +9,8 @@
 - 自检 server 能不能起来 + 给出脱敏摘要
 - 检测 Claude Code / Codex 进程并提示先关再启
 - 当前仅配置 gpt-image-2 / gpt-image-2-openai；Grok 渠道暂时关闭
+- 系统 Python 被发行版标记为 externally-managed（PEP 668，Arch/Debian/Fedora 等）时，
+  自动改用仓库内 .venv 装依赖，并把 venv 的 python 写进客户端配置
 
 用法：
     python install.py
@@ -16,6 +18,8 @@
     python install.py --baseurl https://...        # 高级: 覆盖 baseurl
     python install.py --no-codex                   # 不写 Codex 配置
     python install.py --no-claude                  # 不写 Claude 配置
+    python install.py --venv-dir ~/venvs/micu      # 自定义虚拟环境位置
+    python install.py --break-system-packages      # 硬装进系统 Python (有风险)
     python install.py --yes                        # 非交互, 全用环境变量
         MICU_API_KEY=... MICU_SAVE_DIR=... python install.py --yes
         MICU_API_KEY=... python install.py --yes
@@ -29,12 +33,16 @@ import re
 import shutil
 import subprocess
 import sys
+import sysconfig
+from collections.abc import Sequence
 from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
 from urllib.parse import urlsplit
 
 PY_MIN = (3, 10)
+
+VENV_DIR_NAME = ".venv"
 
 PIP_MIRRORS = {
     "tsinghua": "https://pypi.tuna.tsinghua.edu.cn/simple",
@@ -64,13 +72,33 @@ class RuntimeCommand:
     args: list[str]
 
 
-def resolve_runtime_command(args: argparse.Namespace, repo_root: Path) -> RuntimeCommand:
+@dataclass(frozen=True)
+class PythonEnv:
+    """Python runtime 下装依赖 / 跑 server 用哪个解释器。
+
+    command       : 解释器路径（会写进 Claude/Codex 配置的 command）
+    pip_cmd       : 装包命令前缀，后面接 "install ..."
+    install_extra : 追加给 install 的 flag（--python / --break-system-packages）
+    version_cmd   : 探测包管理器可用性
+    venv          : 项目虚拟环境目录（直接用系统 Python 时为 None）
+    """
+
+    command: str
+    pip_cmd: tuple[str, ...]
+    install_extra: tuple[str, ...]
+    version_cmd: tuple[str, ...]
+    venv: Path | None
+
+
+def resolve_runtime_command(args: argparse.Namespace, repo_root: Path,
+                            python_env: PythonEnv | None = None) -> RuntimeCommand:
     """Resolve the explicit migration runtime without changing the default prematurely."""
     if args.runtime == "python":
         server_path = repo_root / "server.py"
         if not server_path.is_file():
             err(f"找不到 server.py: {server_path}")
-        return RuntimeCommand("python", sys.executable, [str(server_path)])
+        python_exe = python_env.command if python_env else sys.executable
+        return RuntimeCommand("python", python_exe, [str(server_path)])
 
     binary_name = "micu-image-mcp.exe" if sys.platform == "win32" else "micu-image-mcp"
     candidate = (
@@ -178,12 +206,138 @@ def check_python() -> None:
     ok(f"Python {sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}")
 
 
-def check_pip() -> None:
-    p = subprocess.run([sys.executable, "-m", "pip", "--version"],
-                       capture_output=True, text=True)
-    if p.returncode != 0:
+def _run_quiet(cmd: Sequence[str], timeout: int = 60) -> subprocess.CompletedProcess | None:
+    """跑一条探测命令；不存在 / 超时 / 不可执行都返回 None，不抛。"""
+    try:
+        return subprocess.run(list(cmd), capture_output=True, text=True, timeout=timeout,
+                              check=False)
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+
+
+def _venv_python(venv_dir: Path) -> Path:
+    if os.name == "nt":
+        return venv_dir / "Scripts" / "python.exe"
+    return venv_dir / "bin" / "python"
+
+
+def _probe_python(py: Path | str) -> tuple[int, ...] | None:
+    """跑一下解释器拿版本号；不可用（不存在 / base python 被删）返回 None。"""
+    p = _run_quiet([str(py), "-c", "import sys;print('%d.%d.%d' % sys.version_info[:3])"])
+    if p is None or p.returncode != 0:
+        return None
+    m = re.fullmatch(r"(\d+)\.(\d+)\.(\d+)", p.stdout.strip())
+    return tuple(int(g) for g in m.groups()) if m else None
+
+
+def _in_virtualenv() -> bool:
+    """当前解释器是否已经在 venv / conda 里（那就不必再套一层）。
+
+    只看解释器自身的 prefix：VIRTUAL_ENV / CONDA_PREFIX 可能是别的目录残留的
+    （例如 IDE 自动激活过另一个 venv），信它会把系统 Python 误判成虚拟环境，
+    然后 pip 又撞上 PEP 668。
+    """
+    if getattr(sys, "base_prefix", sys.prefix) != sys.prefix:
+        return True
+    if getattr(sys, "real_prefix", None):  # 老版 virtualenv
+        return True
+    return (Path(sys.prefix) / "conda-meta").is_dir()
+
+
+def _is_externally_managed() -> bool:
+    """PEP 668：发行版是否禁止往系统 Python 里 pip install（Arch/Debian/Fedora 等）。"""
+    try:
+        stdlib = Path(sysconfig.get_paths()["stdlib"])
+    except Exception:  # noqa: BLE001 - sysconfig 异常时按“没被管”处理，后面 pip 自己会报错
+        return False
+    return (stdlib / "EXTERNALLY-MANAGED").exists()
+
+
+def _create_venv(venv_dir: Path) -> Path | None:
+    """建虚拟环境：先 stdlib venv（自带 pip），失败再退回 uv（--seed 会带 pip）。"""
+    attempts: list[list[str]] = [[sys.executable, "-m", "venv", str(venv_dir)]]
+    uv = shutil.which("uv")
+    if uv:
+        attempts.append([uv, "venv", "--seed", str(venv_dir)])
+        attempts.append([uv, "venv", str(venv_dir)])
+    for cmd in attempts:
+        info(" ".join(cmd))
+        try:
+            rc = subprocess.run(cmd, check=False).returncode
+        except OSError as e:
+            warn(f"{cmd[0]} 跑不起来: {e}")
+            continue
+        if rc == 0 and _venv_python(venv_dir).exists():
+            return _venv_python(venv_dir)
+        warn("创建失败, 换下一种方式")
+    return None
+
+
+def resolve_python_env(repo_root: Path, *, non_interactive: bool, venv_dir: Path | None,
+                       break_system: bool) -> PythonEnv:
+    """决定 Python runtime 的依赖装到哪、server 用哪个解释器跑。"""
+    step("选择 Python 环境")
+    sys_pip = (sys.executable, "-m", "pip")
+    system_env = PythonEnv(sys.executable, sys_pip, (), (*sys_pip, "--version"), None)
+
+    if _in_virtualenv():
+        ok(f"已在虚拟环境中, 直接用它: {sys.executable}")
+        return system_env
+    if not _is_externally_managed():
+        ok(f"系统 Python 可直接装包: {sys.executable}")
+        return system_env
+    if break_system:
+        warn("系统 Python 被发行版标记为 externally-managed (PEP 668)")
+        warn("--break-system-packages 有可能弄坏发行版自带的 Python 包, 风险自担")
+        return PythonEnv(sys.executable, sys_pip, ("--break-system-packages",),
+                         (*sys_pip, "--version"), None)
+
+    vdir = (venv_dir or repo_root / VENV_DIR_NAME).expanduser()
+    info("系统 Python 受 PEP 668 保护 (externally-managed), 改用虚拟环境装依赖")
+    py = _venv_python(vdir)
+    ver = _probe_python(py)
+
+    if ver is None and vdir.exists():
+        warn(f"{vdir} 已存在但解释器跑不起来 (可能是上次创建中断)")
+        if non_interactive:
+            err(f"请手动删除 {vdir} 后重跑, 或用 --venv-dir 指定别的位置")
+        if ask_yes_no(f"删除 {vdir} 并重建?", default=True):
+            shutil.rmtree(vdir, ignore_errors=True)
+        else:
+            err("已取消. 你可以手动删除后用 --venv-dir 指定别的位置")
+
+    if ver is None:
+        created = _create_venv(vdir)
+        if created is None:
+            err(f"创建虚拟环境失败: {vdir}\n"
+                f"      手动兜底: {sys.executable} -m venv {vdir} 后重跑\n"
+                "      或 (有风险) 加 --break-system-packages 直接装进系统 Python")
+        py, ver = created, _probe_python(created)
+
+    if ver is None or ver[:2] < PY_MIN:
+        cur = ".".join(str(v) for v in ver) if ver else "unknown"
+        err(f"{py} 不可用或版本过低 (需 >= {PY_MIN[0]}.{PY_MIN[1]}, 当前 {cur}); "
+            f"删掉 {vdir} 重跑, 或用 --venv-dir 指定别的位置")
+
+    ok(f"虚拟环境: {vdir} (Python {'.'.join(str(v) for v in ver)})")
+    pip_cmd = (str(py), "-m", "pip")
+    pip_probe = _run_quiet((*pip_cmd, "--version"))
+    if pip_probe is not None and pip_probe.returncode == 0:
+        return PythonEnv(str(py), pip_cmd, (), (*pip_cmd, "--version"), vdir)
+    uv = shutil.which("uv")
+    if uv is None:
+        err(f"{vdir} 里没有 pip, 也没找到 uv.\n"
+            f"      兜底: {py} -m ensurepip --upgrade 后重跑")
+    warn("虚拟环境里没有 pip, 改用 uv 装依赖")
+    return PythonEnv(str(py), (uv, "pip"), ("--python", str(py)), (uv, "--version"), vdir)
+
+
+def check_pip(python_env: PythonEnv) -> None:
+    p = _run_quiet(python_env.version_cmd)
+    if p is None or p.returncode != 0:
         err("pip 不可用. 请先装 pip: https://pip.pypa.io/en/stable/installation/")
-    ok(f"pip 可用: {p.stdout.strip()}")
+    first = (p.stdout or p.stderr or "").strip().splitlines()
+    ok(f"包管理器可用: {first[0] if first else ' '.join(python_env.version_cmd)}")
 
 
 def check_running_clients() -> None:
@@ -219,23 +373,28 @@ def check_running_clients() -> None:
 
 # ---------- 依赖安装 ----------
 
-def install_deps(repo_root: Path, mirror_url: str | None) -> None:
+def install_deps(python_env: PythonEnv, repo_root: Path, mirror_url: str | None) -> None:
     step("安装依赖")
-    extra = ["-i", mirror_url] if mirror_url else []
+    extra: list[str] = list(python_env.install_extra)
     if mirror_url:
         info(f"使用镜像: {mirror_url}")
-    cmd = [sys.executable, "-m", "pip", "install", *extra, "-e", str(repo_root)]
+        extra += ["-i", mirror_url]
+    cmd = [*python_env.pip_cmd, "install", *extra, "-e", str(repo_root)]
     info(" ".join(cmd))
-    rc = subprocess.run(cmd).returncode
+    rc = subprocess.run(cmd, check=False).returncode
     if rc != 0:
         warn("editable install 失败, 改装顶层依赖")
-        cmd2 = [sys.executable, "-m", "pip", "install", *extra,
+        cmd2 = [*python_env.pip_cmd, "install", *extra,
                 "mcp[cli]>=1.0.0", "httpx>=0.27.0", "Pillow>=10.0.0"]
         info(" ".join(cmd2))
-        rc2 = subprocess.run(cmd2).returncode
+        rc2 = subprocess.run(cmd2, check=False).returncode
         if rc2 != 0:
-            err("pip install 失败. 国内用户可加 --mirror tsinghua 重试")
-    ok("依赖就绪")
+            hints = ["国内用户可加 --mirror tsinghua 重试"]
+            if python_env.venv is None and _is_externally_managed():
+                hints.insert(0, "系统 Python 受 PEP 668 保护, 可加 --venv-dir 指定虚拟环境位置, "
+                                "或加 --break-system-packages 硬装 (有风险)")
+            err("依赖安装失败. " + "; ".join(hints))
+    ok(f"依赖就绪 (解释器: {python_env.command})")
 
 
 # ---------- 收集配置 ----------
@@ -269,14 +428,62 @@ def _format_model_list(models: list[str], limit: int = 8) -> str:
     return head + (f", ... +{len(models) - limit}" if len(models) > limit else "")
 
 
-def _model_ids_for_key(baseurl: str, api_key: str) -> tuple[list[str] | None, str | None, int | None]:
-    """Best-effort /v1/models probe. Returns (ids, error, status_code)."""
-    try:
-        import httpx
-    except ImportError:
-        warn("httpx 不可用，跳过 key 分组校验")
-        return None, "httpx unavailable", None
+_PROBE_SNIPPET = r'''
+import json, sys
+import httpx
 
+url = sys.argv[1]
+api_key = sys.stdin.read().strip()
+try:
+    r = httpx.get(url, headers={"Authorization": "Bearer " + api_key}, timeout=20, trust_env=False)
+except BaseException as e:
+    print(json.dumps({"error": "%s: %s" % (type(e).__name__, e)}))
+    raise SystemExit(0)
+out = {"status": r.status_code}
+if r.status_code != 200:
+    out["error"] = "HTTP %s: %s" % (r.status_code, r.text.replace("\n", " ")[:240])
+else:
+    try:
+        data = r.json()
+    except ValueError as e:
+        out["error"] = "invalid JSON: %s" % (e,)
+    else:
+        out["ids"] = [i.get("id", "") for i in data.get("data", [])
+                      if isinstance(i, dict) and isinstance(i.get("id"), str)]
+print(json.dumps(out))
+'''
+
+
+def _model_ids_via_subprocess(python_exe: str, url: str,
+                              api_key: str) -> tuple[list[str] | None, str | None, int | None]:
+    """借目标环境（venv）的解释器跑 /v1/models 探测。
+
+    安装脚本自己跑在系统 Python 上时通常没装 httpx，所以把探测交给装好依赖的那个解释器。
+    key 走 stdin 不进 argv，避免被 ps 看到；子进程只输出一行 JSON。
+    """
+    try:
+        p = subprocess.run([python_exe, "-c", _PROBE_SNIPPET, url],
+                           input=api_key + "\n", capture_output=True, text=True, timeout=40,
+                           check=False)
+    except (OSError, subprocess.TimeoutExpired) as e:
+        return None, f"{type(e).__name__}: {e}", None
+    lines = (p.stdout or "").strip().splitlines()
+    line = next((ln for ln in reversed(lines) if ln.startswith("{")), None)
+    if line is None:
+        tail = ((p.stderr or "") + (p.stdout or "")).strip()[-240:]
+        return None, f"探测子进程没有输出 (rc={p.returncode}): {tail}", None
+    try:
+        obj = json.loads(line)
+    except ValueError:
+        return None, "探测子进程输出不是合法 JSON", None
+    if not isinstance(obj.get("ids"), list):
+        return None, obj.get("error") or "unknown probe error", obj.get("status")
+    return obj["ids"], None, obj.get("status")
+
+
+def _model_ids_for_key(baseurl: str, api_key: str,
+                       python_exe: str | None = None) -> tuple[list[str] | None, str | None, int | None]:
+    """Best-effort /v1/models probe. Returns (ids, error, status_code)."""
     url = baseurl.rstrip("/") + "/v1/models"
     # KEYLEAK-1：拒绝把 key 发往非 https 且非本地的 baseurl（防误把 key 发到攻击者 host）。
     _parts = urlsplit(baseurl)
@@ -287,6 +494,17 @@ def _model_ids_for_key(baseurl: str, api_key: str) -> tuple[list[str] | None, st
             f"拒绝把 key 发往非 https 且非本地的 baseurl（scheme={_parts.scheme!r} host={_host!r}）；"
             f"自定义代理请用 https，本地调试可用 http://localhost"
         ), None
+
+    target = python_exe or sys.executable
+    if target != sys.executable:
+        return _model_ids_via_subprocess(target, url, api_key)
+
+    try:
+        import httpx
+    except ImportError:
+        warn("httpx 不可用，跳过 key 分组校验")
+        return None, "httpx unavailable", None
+
     try:
         r = httpx.get(
             url,
@@ -320,8 +538,9 @@ def _validate_key_group(
     api_key: str,
     expected_models: tuple[str, ...],
     non_interactive: bool,
+    python_exe: str | None = None,
 ) -> bool:
-    ids, error, status_code = _model_ids_for_key(baseurl, api_key)
+    ids, error, status_code = _model_ids_for_key(baseurl, api_key, python_exe)
     if error:
         msg = f"{label} key 分组校验失败: {error}"
         if non_interactive and status_code in (401, 403):
@@ -423,7 +642,8 @@ def _clean_grok_size_mode(value: str) -> str:
     return mode
 
 
-def collect_config(non_interactive: bool, baseurl: str) -> tuple[dict[str, str], str, str]:
+def collect_config(non_interactive: bool, baseurl: str,
+                   python_exe: str | None = None) -> tuple[dict[str, str], str, str]:
     """返回 (env_dict, save_dir, save_dir_root)."""
     home = Path.home()
     default_save = home / "Pictures" / "micu-out"
@@ -439,6 +659,7 @@ def collect_config(non_interactive: bool, baseurl: str) -> tuple[dict[str, str],
             api_key=api_key,
             expected_models=IMAGE2_MODELS,
             non_interactive=True,
+            python_exe=python_exe,
         )
     else:
         print("\n=== 配置米醋 MCP ===")
@@ -463,6 +684,7 @@ def collect_config(non_interactive: bool, baseurl: str) -> tuple[dict[str, str],
                 api_key=api_key,
                 expected_models=IMAGE2_MODELS,
                 non_interactive=False,
+                python_exe=python_exe,
             ):
                 break
             if ask_yes_no("仍然使用这个 Image2 key?", default=False):
@@ -749,8 +971,13 @@ def do_reset(args: argparse.Namespace) -> None:
         info("没有任何文件被改动")
     else:
         ok(f"已处理: {touched}")
-    print("\n注意: pip 安装的包仍保留. 如需彻底卸载, 运行:")
-    print(f"  {sys.executable} -m pip uninstall -y micu-image-mcp")
+    vdir = Path(__file__).resolve().parent / VENV_DIR_NAME
+    if _probe_python(_venv_python(vdir)) is not None:
+        print("\n注意: 依赖装在项目虚拟环境里. 彻底卸载直接删目录即可:")
+        print(f"  rm -rf {vdir}")
+    else:
+        print("\n注意: pip 安装的包仍保留. 如需彻底卸载, 运行:")
+        print(f"  {sys.executable} -m pip uninstall -y micu-image-mcp")
 
 
 # ---------- main ----------
@@ -778,6 +1005,16 @@ def parse_args() -> argparse.Namespace:
         default=None,
         help="已编译/下载的 Rust binary 路径（配合 --runtime rust）",
     )
+    p.add_argument(
+        "--venv-dir",
+        default=None,
+        help=f"虚拟环境位置 (默认: 仓库内 {VENV_DIR_NAME}; 仅系统 Python 受 PEP 668 保护时用到)",
+    )
+    p.add_argument(
+        "--break-system-packages",
+        action="store_true",
+        help="跳过虚拟环境, 用 --break-system-packages 硬装进系统 Python (有风险)",
+    )
     p.add_argument("--reset", action="store_true",
                    help="移除已写入的 micu-image MCP 配置 (Claude + Codex), 不动 pip 包")
     return p.parse_args()
@@ -795,21 +1032,34 @@ def main() -> None:
     check_running_clients()
 
     repo_root = Path(__file__).resolve().parent
-    runtime_command = resolve_runtime_command(args, repo_root)
     info(f"仓库: {repo_root}")
+
+    # Rust runtime 不装 Python 依赖，也就不需要碰虚拟环境
+    python_env = (
+        resolve_python_env(
+            repo_root,
+            non_interactive=args.yes,
+            venv_dir=Path(args.venv_dir).expanduser() if args.venv_dir else None,
+            break_system=args.break_system_packages,
+        )
+        if args.runtime == "python" else None
+    )
+    runtime_command = resolve_runtime_command(args, repo_root, python_env)
     info(
         f"运行时: {runtime_command.runtime} -> "
         f"{[runtime_command.command, *runtime_command.args]}"
     )
 
-    if runtime_command.runtime == "python":
-        check_pip()
+    if runtime_command.runtime == "python" and python_env is not None:
+        check_pip(python_env)
         mirror_url = args.pypi_index or PIP_MIRRORS.get(args.mirror)
-        install_deps(repo_root, mirror_url)
+        install_deps(python_env, repo_root, mirror_url)
     else:
         ok("Rust binary 已就绪；跳过 pip/Python server 依赖安装")
 
-    env_dict, save_dir, save_root = collect_config(args.yes, args.baseurl)
+    env_dict, save_dir, save_root = collect_config(
+        args.yes, args.baseurl, python_env.command if python_env else None
+    )
 
     claude_cfg = (
         write_claude(runtime_command.command, runtime_command.args, env_dict)

--- a/tests/unit/test_install.py
+++ b/tests/unit/test_install.py
@@ -3,8 +3,26 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import subprocess
+import sys
+
+import pytest
 
 import install
+
+
+def _completed(returncode: int = 0, stdout: str = "", stderr: str = "") -> subprocess.CompletedProcess:
+    return subprocess.CompletedProcess(args=[], returncode=returncode, stdout=stdout, stderr=stderr)
+
+
+def _python_env(command: str, venv=None) -> install.PythonEnv:
+    return install.PythonEnv(
+        command=command,
+        pip_cmd=(command, "-m", "pip"),
+        install_extra=(),
+        version_cmd=(command, "-m", "pip", "--version"),
+        venv=venv,
+    )
 
 
 def test_installer_ignores_legacy_grok_environment(monkeypatch, tmp_path):
@@ -57,3 +75,247 @@ def test_phase_a_writers_preserve_other_mcp_servers(monkeypatch, tmp_path):
     assert merged["mcpServers"]["other"]["command"] == "other"
     assert merged["mcpServers"]["micu-image"]["command"] == "/bin/micu"
     assert merged["mcpServers"]["micu-image"]["args"] == []
+
+
+# ---------- PEP 668 / 虚拟环境 ----------
+
+def test_in_virtualenv_ignores_stale_virtual_env_var(monkeypatch, tmp_path):
+    """VIRTUAL_ENV 可能是别的项目残留的；判断只能看解释器自己的 prefix。"""
+    monkeypatch.setenv("VIRTUAL_ENV", str(tmp_path / "other-project" / ".venv"))
+    monkeypatch.setenv("CONDA_PREFIX", str(tmp_path / "conda"))
+    monkeypatch.setattr(install.sys, "prefix", str(tmp_path))
+    monkeypatch.setattr(install.sys, "base_prefix", str(tmp_path), raising=False)
+    assert install._in_virtualenv() is False
+
+
+def test_in_virtualenv_detects_real_venv_by_prefix(monkeypatch, tmp_path):
+    monkeypatch.delenv("VIRTUAL_ENV", raising=False)
+    monkeypatch.delenv("CONDA_PREFIX", raising=False)
+    monkeypatch.setattr(install.sys, "prefix", str(tmp_path / ".venv"))
+    monkeypatch.setattr(install.sys, "base_prefix", str(tmp_path), raising=False)
+    assert install._in_virtualenv() is True
+
+
+def test_is_externally_managed_follows_pep668_marker(monkeypatch, tmp_path):
+    monkeypatch.setattr(install.sysconfig, "get_paths", lambda: {"stdlib": str(tmp_path)})
+    assert install._is_externally_managed() is False
+    (tmp_path / "EXTERNALLY-MANAGED").write_text("do not pip install here\n", encoding="utf-8")
+    assert install._is_externally_managed() is True
+
+
+def test_venv_python_layout_per_platform(monkeypatch, tmp_path):
+    monkeypatch.setattr(install.os, "name", "nt")
+    assert install._venv_python(tmp_path) == tmp_path / "Scripts" / "python.exe"
+    monkeypatch.setattr(install.os, "name", "posix")
+    assert install._venv_python(tmp_path) == tmp_path / "bin" / "python"
+
+
+def _stub_managed_system(monkeypatch) -> None:
+    monkeypatch.setattr(install, "_in_virtualenv", lambda: False)
+    monkeypatch.setattr(install, "_is_externally_managed", lambda: True)
+
+
+def test_resolve_python_env_creates_venv_when_system_python_is_managed(monkeypatch, tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    vdir = repo / install.VENV_DIR_NAME
+    _stub_managed_system(monkeypatch)
+    # 第一次探测: .venv 还不存在; 创建之后再探测: 拿到版本
+    probes = iter([None, (3, 12, 0)])
+    monkeypatch.setattr(install, "_probe_python", lambda py: next(probes))
+    created = []
+    monkeypatch.setattr(install, "_create_venv",
+                        lambda d: created.append(d) or install._venv_python(d))
+    monkeypatch.setattr(install, "_run_quiet", lambda cmd, timeout=60: _completed(0, "pip 26.1.2"))
+
+    env = install.resolve_python_env(repo, non_interactive=True, venv_dir=None, break_system=False)
+
+    assert created == [vdir]
+    assert env.command == str(install._venv_python(vdir))
+    assert env.venv == vdir
+    assert env.pip_cmd == (str(install._venv_python(vdir)), "-m", "pip")
+    assert env.install_extra == ()
+
+
+def test_resolve_python_env_reuses_working_venv_without_recreating(monkeypatch, tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    vpy = install._venv_python(repo / install.VENV_DIR_NAME)
+    _stub_managed_system(monkeypatch)
+    monkeypatch.setattr(install, "_probe_python", lambda py: (3, 13, 1))
+    monkeypatch.setattr(install, "_run_quiet", lambda cmd, timeout=60: _completed(0, "pip 26.1.2"))
+
+    def _boom(_dir):
+        raise AssertionError("可用的 .venv 不该被重建")
+
+    monkeypatch.setattr(install, "_create_venv", _boom)
+
+    env = install.resolve_python_env(repo, non_interactive=True, venv_dir=None, break_system=False)
+    assert env.command == str(vpy)
+
+
+def test_resolve_python_env_honours_custom_venv_dir(monkeypatch, tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    custom = tmp_path / "venvs" / "micu"
+    _stub_managed_system(monkeypatch)
+    monkeypatch.setattr(install, "_probe_python", lambda py: (3, 12, 0))
+    monkeypatch.setattr(install, "_run_quiet", lambda cmd, timeout=60: _completed(0, "pip 26.1.2"))
+
+    env = install.resolve_python_env(repo, non_interactive=True, venv_dir=custom, break_system=False)
+
+    assert env.venv == custom
+    assert env.command == str(install._venv_python(custom))
+    assert not (repo / install.VENV_DIR_NAME).exists()
+
+
+def test_resolve_python_env_falls_back_to_uv_when_venv_has_no_pip(monkeypatch, tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    vpy = install._venv_python(repo / install.VENV_DIR_NAME)
+    _stub_managed_system(monkeypatch)
+    monkeypatch.setattr(install, "_probe_python", lambda py: (3, 12, 0))
+    monkeypatch.setattr(install, "_run_quiet",
+                        lambda cmd, timeout=60: _completed(1, "", "No module named pip"))
+    monkeypatch.setattr(install.shutil, "which", lambda name: "/usr/bin/uv" if name == "uv" else None)
+
+    env = install.resolve_python_env(repo, non_interactive=True, venv_dir=None, break_system=False)
+
+    assert env.pip_cmd == ("/usr/bin/uv", "pip")
+    assert env.install_extra == ("--python", str(vpy))
+
+
+def test_resolve_python_env_keeps_system_python_when_not_managed(monkeypatch, tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    monkeypatch.setattr(install, "_in_virtualenv", lambda: False)
+    monkeypatch.setattr(install, "_is_externally_managed", lambda: False)
+
+    env = install.resolve_python_env(repo, non_interactive=True, venv_dir=None, break_system=False)
+
+    assert env.command == sys.executable
+    assert env.venv is None
+    assert not (repo / install.VENV_DIR_NAME).exists()
+
+
+def test_resolve_python_env_break_system_packages_skips_venv(monkeypatch, tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _stub_managed_system(monkeypatch)
+
+    env = install.resolve_python_env(repo, non_interactive=True, venv_dir=None, break_system=True)
+
+    assert env.command == sys.executable
+    assert env.venv is None
+    assert env.install_extra == ("--break-system-packages",)
+    assert not (repo / install.VENV_DIR_NAME).exists()
+
+
+def test_resolve_python_env_rejects_broken_venv_in_non_interactive(monkeypatch, tmp_path, capsys):
+    repo = tmp_path / "repo"
+    install._venv_python(repo / install.VENV_DIR_NAME).parent.mkdir(parents=True)
+    _stub_managed_system(monkeypatch)
+    monkeypatch.setattr(install, "_probe_python", lambda py: None)
+
+    with pytest.raises(SystemExit) as exc:
+        install.resolve_python_env(repo, non_interactive=True, venv_dir=None, break_system=False)
+
+    assert exc.value.code == 1
+    assert "--venv-dir" in capsys.readouterr().out
+
+
+def test_install_deps_installs_into_selected_env(monkeypatch, tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    calls: list[list[str]] = []
+
+    def _fake_run(cmd, **_kwargs):
+        calls.append(list(cmd))
+        return _completed(0)
+
+    monkeypatch.setattr(install.subprocess, "run", _fake_run)
+    env = _python_env(str(tmp_path / ".venv" / "bin" / "python"), tmp_path / ".venv")
+
+    install.install_deps(env, repo, "https://pypi.tuna.tsinghua.edu.cn/simple")
+
+    assert calls == [[*env.pip_cmd, "install",
+                      "-i", "https://pypi.tuna.tsinghua.edu.cn/simple", "-e", str(repo)]]
+
+
+def test_install_deps_failure_hints_pep668_for_system_python(monkeypatch, tmp_path, capsys):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    monkeypatch.setattr(install.subprocess, "run", lambda cmd, **_kwargs: _completed(1))
+    monkeypatch.setattr(install, "_is_externally_managed", lambda: True)
+
+    with pytest.raises(SystemExit):
+        install.install_deps(_python_env(sys.executable), repo, None)
+
+    out = capsys.readouterr().out
+    assert "PEP 668" in out
+    assert "--venv-dir" in out
+
+
+def test_runtime_command_uses_selected_python_env(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "server.py").write_text("", encoding="utf-8")
+    args = argparse.Namespace(runtime="python", rust_binary=None)
+    env = _python_env(str(tmp_path / ".venv" / "bin" / "python"), tmp_path / ".venv")
+
+    resolved = install.resolve_runtime_command(args, repo, env)
+
+    assert resolved.command == env.command
+    assert resolved.args == [str(repo / "server.py")]
+
+
+# ---------- /v1/models 探测走目标解释器 ----------
+
+def test_probe_uses_target_python_and_keeps_key_out_of_argv(monkeypatch):
+    seen: dict[str, object] = {}
+
+    def _fake_run(cmd, **kwargs):
+        seen["cmd"] = list(cmd)
+        seen["input"] = kwargs.get("input")
+        return _completed(0, json.dumps({"status": 200, "ids": ["gpt-image-2"]}) + "\n")
+
+    monkeypatch.setattr(install.subprocess, "run", _fake_run)
+
+    ids, error, status = install._model_ids_for_key(
+        install.DEFAULT_BASEURL, "sk-probe-key", "/venv/bin/python"
+    )
+
+    assert (ids, error, status) == (["gpt-image-2"], None, 200)
+    assert seen["cmd"][0] == "/venv/bin/python"
+    assert "sk-probe-key" not in seen["cmd"]
+    assert seen["input"] == "sk-probe-key\n"
+
+
+def test_probe_surfaces_child_error(monkeypatch):
+    monkeypatch.setattr(
+        install.subprocess, "run",
+        lambda cmd, **kwargs: _completed(0, json.dumps({"status": 401, "error": "HTTP 401: bad key"})),
+    )
+
+    ids, error, status = install._model_ids_for_key(
+        install.DEFAULT_BASEURL, "sk-probe-key", "/venv/bin/python"
+    )
+
+    assert ids is None
+    assert status == 401
+    assert "HTTP 401" in error
+
+
+def test_probe_refuses_non_https_baseurl_before_spawning_child(monkeypatch):
+    def _boom(*_args, **_kwargs):
+        raise AssertionError("拒绝 baseurl 之后不该再起子进程")
+
+    monkeypatch.setattr(install.subprocess, "run", _boom)
+
+    ids, error, status = install._model_ids_for_key(
+        "http://evil.example", "sk-probe-key", "/venv/bin/python"
+    )
+
+    assert ids is None
+    assert status is None
+    assert "https" in error


### PR DESCRIPTION
Fixes #5

## 问题

Arch / Debian / Fedora 等发行版按 [PEP 668](https://peps.python.org/pep-0668/) 把系统 Python 标记为
`externally-managed`，`python install.py --runtime python` 的两次 `pip install`（editable + 顶层依赖兜底）
都被 pip 拒绝，安装直接终止，Claude/Codex 配置也没写入。`--mirror tsinghua` 对这个错误无效——不是网络问题。

根因是三处写死 `sys.executable`：`install_deps()`、`check_pip()`，以及 `resolve_runtime_command()` 里的
`RuntimeCommand("python", sys.executable, ...)`——即使依赖装到别处，写进配置的 `command` 仍是系统 Python。

## 解决方案

1. **环境解析**（新增 `PythonEnv` + `resolve_python_env()`）
   - 已经在 venv/conda 里 → 行为不变
   - 系统 Python 没有 `EXTERNALLY-MANAGED` 标记 → 行为不变
   - 被 PEP 668 锁住 → 复用仓库内 `.venv`；不存在则创建（`python -m venv` → `uv venv --seed` → `uv venv`）
   - venv 内没有 pip（`uv venv` 不带 `--seed` 的情况）→ 退回 `uv pip install --python <venv python>`
   - `.venv` 存在但解释器跑不起来（上次创建中断）→ 交互下问一句再重建，`--yes` 下报错让用户处理
2. **统一解释器**：装依赖、写入 `~/.claude.json` / `~/.codex/config.toml` 的 `command`、`smoke_test`
   启动的 server、`summary` 输出，全部用选定的那个解释器
3. **key 校验跟着走**：`/v1/models` 探测改由目标解释器跑子进程。installer 自身在系统 Python 上通常没有
   httpx，旧逻辑会静默跳过校验（只留一句 `httpx 不可用`）。key 走 stdin 不进 argv，避免被 `ps` 看到；
   KEYLEAK-1 的「非 https 且非本地 baseurl 直接拒绝」仍在父进程先判，不会为了要拒绝的 baseurl 起子进程
4. **venv 判定只看 prefix**：`sys.prefix != sys.base_prefix`（外加 `real_prefix` / `conda-meta`）。
   不看 `VIRTUAL_ENV` / `CONDA_PREFIX`——IDE 常残留别的项目的值，信它会把系统 Python 误判成 venv，
   然后 pip 再次撞上 PEP 668（本机就是这么踩到的，已加回归用例）
5. **逃生门**：`--venv-dir <path>` 指定虚拟环境位置；`--break-system-packages` 明确知情后硬装系统 Python
6. `--runtime rust` 不解析 Python 环境、不创建 `.venv`（它本来就不装 Python 依赖）；
   `resolve_runtime_command()` 的第三个参数可选，不传时仍是 `sys.executable`，旧调用方不受影响

## 文档

- README「Python reference（保留/回滚）」补 PEP 668 / `.venv` 行为与两个新选项
- `docs/migration-from-python.md` 同步；回滚一节的「改回当前 Python」明确成「PEP 668 时是 `.venv/bin/python`」

## 变更文件

- `install.py` — 新增 `PythonEnv` / `resolve_python_env()` / `_create_venv()` / `_is_externally_managed()` /
  `_in_virtualenv()` / `_probe_python()` / `_venv_python()` / `_run_quiet()` / `_model_ids_via_subprocess()`；
  `install_deps`、`check_pip`、`resolve_runtime_command`、`collect_config`、`_validate_key_group`、
  `_model_ids_for_key`、`do_reset` 接选定解释器；新增 `--venv-dir` / `--break-system-packages`
- `tests/unit/test_install.py` — 新增 17 个用例（venv 判定、PEP 668 标记、创建/复用/损坏/自定义位置、
  uv 回退、install_deps 命令拼装与失败提示、RuntimeCommand、探测子进程的 key 不进 argv）
- `README.md`、`docs/migration-from-python.md`

## Test plan

- [x] `python -m pytest -q`（Python 3.13，`MICU_RUN_LIVE_TESTS=0`）— 351 passed, 11 skipped
- [x] `python tests/smoke_local.py` — 全部通过
- [x] Arch 实机（系统 Python 3.14 + `EXTERNALLY-MANAGED`）`python install.py --yes --runtime python`：
      自动复用 `.venv`，依赖装进 venv，`~/.claude.json` 与 `~/.codex/config.toml` 的 `command` 都是
      `.venv/bin/python`，initialize 握手 + `tools/list` 5 个 tool 全通过
- [x] 全新 venv：`--venv-dir /tmp/...` 由系统 Python 3.14 创建并装依赖成功
- [x] `uv venv`（无 pip）→ 自动改用 `uv pip install --python`
- [x] 损坏 `.venv`：交互下询问重建，`--yes` 下报错并提示 `--venv-dir`
- [x] 残留 `VIRTUAL_ENV` 指向别的目录时不再误判为虚拟环境
- [x] 已在 venv / 未被 PEP 668 管理的环境：返回系统 Python，不创建 `.venv`
