### PR TITLE
fix(installer): main 的 Python 回滚安装支持 PEP 668 虚拟环境

### DIFF
--- a/docs/python-installer.md
+++ b/docs/python-installer.md
@@ -1,0 +1,98 @@
+# Python reference installer: PEP 668 and virtual environments
+
+This is the legacy/source-tree Python installer, not the supported Rust release
+installer. New Rust installations should use the Rust binary's `install` command.
+Neither the Rust release workflow nor its artifacts are changed by this fix.
+
+## Run the correct installer for your branch
+
+On `main`, explicitly select the Python rollback runtime:
+
+```sh
+python install.py --runtime python
+```
+
+On the Python-only `python-reference` branch, there is no `--runtime` option:
+
+```sh
+python install.py
+```
+
+Both support `--yes` with `MICU_API_KEY` and optional `MICU_SAVE_DIR` environment
+variables. Do not put real keys in commands, issue reports, or screenshots.
+
+## Environment selection
+
+When the interpreter is not already in a virtual environment and its standard
+library contains the `EXTERNALLY-MANAGED` marker, the installer creates or reuses
+`<repository>/.venv`. It then restarts itself using that environment's Python.
+Dependency installation, `/v1/models` key-group validation, the startup smoke test,
+and the command written to Claude/Codex therefore use the same interpreter.
+The system interpreter does not need pip or httpx for this bootstrap.
+
+Existing venv/virtualenv environments are detected from the interpreter's prefixes;
+Conda is recognized by `conda-meta` under its actual prefix. Stale `VIRTUAL_ENV` or
+`CONDA_PREFIX` shell variables do not establish which interpreter is running.
+Without an explicit destination, an active environment or an unmanaged system
+interpreter keeps the previous installation behavior.
+
+To select a different environment, including on an unmanaged interpreter or while
+another venv is active:
+
+```sh
+python install.py --venv-dir "$HOME/venvs/micu"
+```
+
+Relative paths are relative to the current working directory and are made absolute
+before launch/configuration. Paths containing spaces are supported. No shell
+activation is required. Do not move/delete the chosen environment or this source
+checkout while a client configuration still references them.
+
+## Creating and recovering environments
+
+Creation prefers `python -m venv`. If unavailable, an installed `uv` is tried with
+`venv --seed` and an explicit `--python` matching the installer interpreter. A
+missing pip inside a valid target is bootstrapped with `ensurepip`, then an installed
+`uv` if necessary. `--mirror` / `--pypi-index` also apply to uv package downloads.
+The installer does not install uv or modify OS packages on your behalf.
+
+Existing targets must contain `pyvenv.cfg`, run Python 3.10 or later, and report the
+expected virtual-environment prefix. An invalid target is **never recursively
+deleted or automatically replaced**. Repair it manually or choose a new
+`--venv-dir`; partially created environments are preserved as well. On
+Debian/Ubuntu, a missing stdlib venv/ensurepip commonly requires the distribution's
+`python3-venv` package. Changing a package index cannot fix a PEP 668 restriction.
+
+The risky override is opt-in only:
+
+```sh
+python install.py --break-system-packages
+```
+
+This forwards the flag to both pip installation paths and may damage
+OS-managed Python packages. It cannot be combined with `--venv-dir` and is not the
+recommended workaround. The normal PEP 668 path never enables it automatically.
+
+`--help`, `--reset`, and `--runtime rust` on `main` do not create a Python environment
+or install Python server dependencies. Reset removes the managed client entries,
+not the environment or installed packages. Use the Python command from the old
+client configuration when uninstalling packages; do not assume it was system Python.
+
+## Regression coverage
+
+Run `python -m pytest -q tests/unit/test_installer_env.py`. Tests cover marker and
+prefix detection, stale activation variables, destination precedence, absolute
+paths, invalid-directory preservation, creation/pip fallback command routing,
+explicit overrides, reset/help, and the Rust bypass where available.
+
+The integration regression uses a real temporary venv, interpreter re-execution,
+client configuration writes, and stdio subprocess. Its pip, httpx, and MCP server
+are offline test doubles: it verifies interpreter routing, not real dependency
+resolution or the remote image API. No user configuration or real API credentials
+are used. Native platform CI and live-service validation are separate checks.
+
+This addresses issue #5, reported by @tingfeng347. Reference specifications:
+
+- [Externally Managed Environments](https://packaging.python.org/en/latest/specifications/externally-managed-environments/)
+- [Python venv](https://docs.python.org/3/library/venv.html)
+- [uv command reference](https://docs.astral.sh/uv/reference/cli/)

--- a/install.py
+++ b/install.py
@@ -16,6 +16,8 @@
     python install.py --baseurl https://...        # 高级: 覆盖 baseurl
     python install.py --no-codex                   # 不写 Codex 配置
     python install.py --no-claude                  # 不写 Claude 配置
+    python install.py --venv-dir ~/venvs/micu      # 指定 Python 虚拟环境
+    python install.py --break-system-packages      # 显式绕过 PEP 668 (有风险)
     python install.py --yes                        # 非交互, 全用环境变量
         MICU_API_KEY=... MICU_SAVE_DIR=... python install.py --yes
         MICU_API_KEY=... python install.py --yes
@@ -33,6 +35,8 @@ from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
 from urllib.parse import urlsplit
+
+from installer_env import prepare_python
 
 PY_MIN = (3, 10)
 
@@ -219,9 +223,12 @@ def check_running_clients() -> None:
 
 # ---------- 依赖安装 ----------
 
-def install_deps(repo_root: Path, mirror_url: str | None) -> None:
+def install_deps(repo_root: Path, mirror_url: str | None, *,
+                 break_system_packages: bool = False) -> None:
     step("安装依赖")
     extra = ["-i", mirror_url] if mirror_url else []
+    if break_system_packages:
+        extra.append("--break-system-packages")
     if mirror_url:
         info(f"使用镜像: {mirror_url}")
     cmd = [sys.executable, "-m", "pip", "install", *extra, "-e", str(repo_root)]
@@ -234,7 +241,8 @@ def install_deps(repo_root: Path, mirror_url: str | None) -> None:
         info(" ".join(cmd2))
         rc2 = subprocess.run(cmd2).returncode
         if rc2 != 0:
-            err("pip install 失败. 国内用户可加 --mirror tsinghua 重试")
+            err("pip install 失败，请检查上方错误。网络问题可尝试 --mirror tsinghua；"
+                "环境或权限问题请使用 --venv-dir 指定可写的新目录。")
     ok("依赖就绪")
 
 
@@ -749,8 +757,7 @@ def do_reset(args: argparse.Namespace) -> None:
         info("没有任何文件被改动")
     else:
         ok(f"已处理: {touched}")
-    print("\n注意: pip 安装的包仍保留. 如需彻底卸载, 运行:")
-    print(f"  {sys.executable} -m pip uninstall -y micu-image-mcp")
+    print("\n注意: 虚拟环境和 pip 包仍保留；卸载时请使用原客户端配置 command 对应的 Python。")
 
 
 # ---------- main ----------
@@ -778,6 +785,11 @@ def parse_args() -> argparse.Namespace:
         default=None,
         help="已编译/下载的 Rust binary 路径（配合 --runtime rust）",
     )
+    environment = p.add_mutually_exclusive_group()
+    environment.add_argument("--venv-dir", default=None,
+                             help="指定 Python 虚拟环境目录；默认仅在 PEP 668 系统上使用仓库 .venv")
+    environment.add_argument("--break-system-packages", action="store_true",
+                             help="显式允许 pip 修改受保护的系统 Python (有风险)")
     p.add_argument("--reset", action="store_true",
                    help="移除已写入的 micu-image MCP 配置 (Claude + Codex), 不动 pip 包")
     return p.parse_args()
@@ -795,6 +807,12 @@ def main() -> None:
     check_running_clients()
 
     repo_root = Path(__file__).resolve().parent
+    if args.runtime == "python":
+        prepare_python(
+            repo_root, venv_dir=args.venv_dir,
+            break_system_packages=args.break_system_packages,
+            mirror_url=args.pypi_index or PIP_MIRRORS.get(args.mirror),
+        )
     runtime_command = resolve_runtime_command(args, repo_root)
     info(f"仓库: {repo_root}")
     info(
@@ -805,7 +823,7 @@ def main() -> None:
     if runtime_command.runtime == "python":
         check_pip()
         mirror_url = args.pypi_index or PIP_MIRRORS.get(args.mirror)
-        install_deps(repo_root, mirror_url)
+        install_deps(repo_root, mirror_url, break_system_packages=args.break_system_packages)
     else:
         ok("Rust binary 已就绪；跳过 pip/Python server 依赖安装")
 

--- a/installer_env.py
+++ b/installer_env.py
@@ -1,0 +1,163 @@
+"""Standard-library-only bootstrap for the source-tree Python installer."""
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+import sysconfig
+from pathlib import Path
+
+PY_MIN = (3, 10)
+
+
+def in_virtual_environment() -> bool:
+    """Inspect this interpreter, never stale shell activation variables."""
+    return (
+        sys.prefix != sys.base_prefix
+        or hasattr(sys, "real_prefix")
+        or (Path(sys.prefix) / "conda-meta").is_dir()
+    )
+
+
+def externally_managed() -> bool:
+    if in_virtual_environment():
+        return False
+    stdlib = sysconfig.get_path("stdlib", sysconfig.get_default_scheme())
+    return (Path(stdlib) / "EXTERNALLY-MANAGED").is_file()
+
+
+def venv_python(directory: Path) -> Path:
+    # Resolving the executable itself can follow a symlink back to system Python.
+    return directory / ("Scripts/python.exe" if os.name == "nt" else "bin/python")
+
+
+def _venv_environ(python: Path) -> dict[str, str]:
+    env = os.environ.copy()
+    env.pop("PYTHONHOME", None)  # This overrides pyvenv.cfg even with an absolute command.
+    env["VIRTUAL_ENV"] = str(python.parent.parent)
+    env["PATH"] = str(python.parent) + os.pathsep + env.get("PATH", "")
+    return env
+
+
+def _succeeds(command: list[str], *, quiet: bool = False,
+              env: dict[str, str] | None = None) -> bool:
+    try:
+        result = subprocess.run(command, capture_output=quiet, text=True,
+                                timeout=120, check=False, env=env)
+        return result.returncode == 0
+    except (OSError, subprocess.TimeoutExpired):
+        return False
+
+
+def _validate_venv(directory: Path) -> Path:
+    python = venv_python(directory)
+    message = (
+        f"{directory} 不是可用的 Python >= 3.10 虚拟环境。"
+        "已有文件保持不变；请修复该环境，或用 --venv-dir 指定新的目录。"
+    )
+    if not (directory / "pyvenv.cfg").is_file():
+        raise SystemExit(f"[ERR] {message}")
+    probe = (
+        "import json,sys;print(json.dumps([list(sys.version_info[:2]),"
+        "sys.prefix,sys.base_prefix]))"
+    )
+    try:
+        result = subprocess.run([str(python), "-I", "-c", probe],
+                                capture_output=True, text=True, timeout=15,
+                                check=False)
+        version, prefix, base_prefix = json.loads(result.stdout)
+        valid = (
+            result.returncode == 0
+            and tuple(version) >= PY_MIN
+            and prefix != base_prefix
+            and Path(prefix).resolve() == directory
+        )
+    except (OSError, subprocess.TimeoutExpired, ValueError, TypeError):
+        valid = False
+    if not valid:
+        raise SystemExit(f"[ERR] {message}")
+    return python
+
+
+def _create_venv(directory: Path, mirror_url: str | None) -> None:
+    # Claim a new directory; never clear, repair or remove a pre-existing one.
+    try:
+        directory.mkdir(parents=True, exist_ok=False)
+    except OSError as exc:
+        raise SystemExit(f"[ERR] 无法创建虚拟环境目录 {directory}: {exc}") from exc
+    print(f"[..] 创建虚拟环境: {directory}", flush=True)
+    if _succeeds([sys.executable, "-m", "venv", str(directory)]):
+        return
+    uv = shutil.which("uv")
+    if uv:
+        print("[!!] python -m venv 失败，尝试 uv venv --seed", flush=True)
+        command = [uv, "venv", "--seed", "--allow-existing", "--no-config",
+                   "--python", sys.executable, str(directory)]
+        if mirror_url:
+            command += ["--index-url", mirror_url]
+        # A shell's UV_VENV_CLEAR must not turn this fallback into a deletion.
+        env = {**os.environ, "UV_VENV_CLEAR": "false"}
+        if _succeeds(command, env=env):
+            return
+    raise SystemExit(
+        f"[ERR] 创建虚拟环境失败: {directory}。请安装发行版的 venv/ensurepip 支持"
+        "（Debian/Ubuntu 通常为 python3-venv），或安装 uv 后指定一个新目录重试。"
+        "未向系统 Python 安装依赖；部分创建的目录已保留。"
+    )
+
+
+def _ensure_pip(python: Path, mirror_url: str | None) -> None:
+    env = _venv_environ(python)
+    if _succeeds([str(python), "-m", "pip", "--version"], quiet=True, env=env):
+        return
+    if _succeeds([str(python), "-m", "ensurepip", "--upgrade"], env=env):
+        return
+    uv = shutil.which("uv")
+    if uv:
+        command = [uv, "pip", "install", "--no-config", "--python", str(python), "pip"]
+        if mirror_url:
+            command += ["--index-url", mirror_url]
+        if _succeeds(command, env=env):
+            return
+    raise SystemExit(
+        f"[ERR] 虚拟环境缺少 pip: {python}。请为此环境安装 pip/ensurepip，"
+        "或安装 uv 后重试。未向系统 Python 安装依赖。"
+    )
+
+
+def prepare_python(repo_root: Path, *, venv_dir: str | None = None,
+                   break_system_packages: bool = False,
+                   mirror_url: str | None = None) -> None:
+    """Re-exec in the selected venv so pip, HTTP probes and configs agree.
+
+    Must run before pip checks, dependency imports, prompts and config writes.
+    Rust, reset and help paths must not call this function.
+    """
+    if break_system_packages:
+        if venv_dir is not None:
+            raise SystemExit("[ERR] --venv-dir 与 --break-system-packages 不能同时使用")
+        print("[!!] 已显式启用 --break-system-packages；可能破坏系统 Python 包。", flush=True)
+        return
+    # An explicit destination takes precedence even in an unmanaged/active env.
+    if venv_dir is None:
+        if not externally_managed():
+            return
+        print("[..] 系统 Python 受 PEP 668 保护，改用仓库 .venv", flush=True)
+    directory = Path(venv_dir).expanduser() if venv_dir is not None else repo_root / ".venv"
+    directory = directory.resolve()
+    if in_virtual_environment() and Path(sys.prefix).resolve() == directory:
+        return  # The re-executed installer has arrived in its target environment.
+    if not directory.exists():
+        _create_venv(directory, mirror_url)
+    python = _validate_venv(directory)
+    _ensure_pip(python, mirror_url)
+    print(f"[..] 使用虚拟环境 Python: {python}", flush=True)
+    sys.stdout.flush()
+    sys.stderr.flush()
+    command = [str(python), str(repo_root / "install.py"), *sys.argv[1:]]
+    try:
+        os.execve(str(python), command, _venv_environ(python))
+    except OSError as exc:
+        raise SystemExit(f"[ERR] 无法启动虚拟环境 Python {python}: {exc}") from exc

--- a/tests/unit/test_installer_env.py
+++ b/tests/unit/test_installer_env.py
@@ -1,0 +1,338 @@
+"""Offline regressions for issue #5; no user config or real API keys are used."""
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import sys
+from types import SimpleNamespace
+from unittest.mock import Mock
+import venv
+
+import pytest
+
+import install
+import installer_env as bootstrap
+
+
+def system_python(monkeypatch, tmp_path):
+    monkeypatch.setattr(bootstrap.sys, "prefix", str(tmp_path / "system"))
+    monkeypatch.setattr(bootstrap.sys, "base_prefix", str(tmp_path / "system"))
+    monkeypatch.delattr(bootstrap.sys, "real_prefix", raising=False)
+    monkeypatch.setattr(bootstrap.sysconfig, "get_path", lambda *a: str(tmp_path))
+
+
+def test_marker_and_stale_activation_variables(monkeypatch, tmp_path):
+    system_python(monkeypatch, tmp_path)
+    monkeypatch.setenv("VIRTUAL_ENV", str(tmp_path / "unrelated"))
+    monkeypatch.setenv("CONDA_PREFIX", str(tmp_path / "unrelated"))
+    assert not bootstrap.externally_managed()
+    (tmp_path / "EXTERNALLY-MANAGED").write_text("[externally-managed]\n")
+    assert bootstrap.externally_managed()
+
+
+def test_marker_directory_is_not_a_marker_file(monkeypatch, tmp_path):
+    system_python(monkeypatch, tmp_path)
+    (tmp_path / "EXTERNALLY-MANAGED").mkdir()
+    assert not bootstrap.externally_managed()
+
+
+@pytest.mark.parametrize("kind", ["venv", "virtualenv", "conda"])
+def test_actual_environments_ignore_marker(monkeypatch, tmp_path, kind):
+    system_python(monkeypatch, tmp_path)
+    (tmp_path / "EXTERNALLY-MANAGED").touch()
+    if kind == "venv":
+        monkeypatch.setattr(bootstrap.sys, "prefix", str(tmp_path / "active"))
+    elif kind == "virtualenv":
+        monkeypatch.setattr(bootstrap.sys, "real_prefix", "/base", raising=False)
+    else:
+        (Path(bootstrap.sys.prefix) / "conda-meta").mkdir(parents=True)
+    assert bootstrap.in_virtual_environment()
+    assert not bootstrap.externally_managed()
+
+
+@pytest.mark.parametrize("managed,explicit", [(True, None), (False, "custom env"), (True, "custom env")])
+def test_selects_absolute_target_and_reexecs(monkeypatch, tmp_path, managed, explicit):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(bootstrap, "externally_managed", lambda: managed)
+    monkeypatch.setattr(bootstrap, "in_virtual_environment", lambda: False)
+    create = Mock()
+    ensure = Mock()
+    execute = Mock()
+    monkeypatch.setattr(bootstrap, "_create_venv", create)
+    monkeypatch.setattr(bootstrap, "_validate_venv", bootstrap.venv_python)
+    monkeypatch.setattr(bootstrap, "_ensure_pip", ensure)
+    monkeypatch.setattr(bootstrap.os, "execve", execute)
+    monkeypatch.setattr(sys, "argv", ["install.py", "--yes"])
+    monkeypatch.setenv("MICU_API_KEY", "sk-test-fixture")
+    monkeypatch.setenv("PYTHONHOME", "/stale-python-home")
+    bootstrap.prepare_python(tmp_path, venv_dir=explicit, mirror_url="https://index.invalid/simple")
+    directory = (tmp_path / (explicit or ".venv")).resolve()
+    python = bootstrap.venv_python(directory)
+    create.assert_called_once_with(directory, "https://index.invalid/simple")
+    ensure.assert_called_once_with(python, "https://index.invalid/simple")
+    executable, argv, env = execute.call_args.args
+    assert executable == str(python)
+    assert argv == [str(python), str(tmp_path / "install.py"), "--yes"]
+    assert "sk-test-fixture" not in repr(argv)
+    assert env["MICU_API_KEY"] == "sk-test-fixture"
+    assert "PYTHONHOME" not in env
+    assert env["VIRTUAL_ENV"] == str(directory)
+
+
+def test_unmanaged_default_does_nothing(monkeypatch, tmp_path):
+    monkeypatch.setattr(bootstrap, "externally_managed", lambda: False)
+    create = Mock(side_effect=AssertionError("must not create"))
+    monkeypatch.setattr(bootstrap, "_create_venv", create)
+    bootstrap.prepare_python(tmp_path)
+    create.assert_not_called()
+
+
+def test_explicit_target_can_switch_from_active_venv(monkeypatch, tmp_path):
+    monkeypatch.setattr(bootstrap, "in_virtual_environment", lambda: True)
+    monkeypatch.setattr(bootstrap.sys, "prefix", str(tmp_path / "old"))
+    monkeypatch.setattr(bootstrap, "_create_venv", Mock())
+    monkeypatch.setattr(bootstrap, "_validate_venv", bootstrap.venv_python)
+    monkeypatch.setattr(bootstrap, "_ensure_pip", Mock())
+    execute = Mock()
+    monkeypatch.setattr(bootstrap.os, "execve", execute)
+    bootstrap.prepare_python(tmp_path, venv_dir=str(tmp_path / "new"))
+    assert execute.call_args.args[0] == str(bootstrap.venv_python(tmp_path / "new"))
+
+
+def test_already_in_explicit_target_does_not_loop(monkeypatch, tmp_path):
+    monkeypatch.setattr(bootstrap, "in_virtual_environment", lambda: True)
+    monkeypatch.setattr(bootstrap.sys, "prefix", str(tmp_path))
+    execute = Mock(side_effect=AssertionError("re-exec loop"))
+    monkeypatch.setattr(bootstrap.os, "execve", execute)
+    bootstrap.prepare_python(tmp_path, venv_dir=str(tmp_path))
+    execute.assert_not_called()
+
+
+def test_break_system_is_explicit_and_conflicts_with_venv(monkeypatch, tmp_path, capsys):
+    create = Mock(side_effect=AssertionError("must not create"))
+    monkeypatch.setattr(bootstrap, "_create_venv", create)
+    bootstrap.prepare_python(tmp_path, break_system_packages=True)
+    assert "--break-system-packages" in capsys.readouterr().out
+    with pytest.raises(SystemExit, match="不能同时使用"):
+        bootstrap.prepare_python(tmp_path, venv_dir="target", break_system_packages=True)
+    create.assert_not_called()
+
+
+def test_invalid_existing_directory_is_preserved(monkeypatch, tmp_path):
+    marker = tmp_path / "important.txt"
+    marker.write_text("keep this")
+    with pytest.raises(SystemExit, match="已有文件保持不变"):
+        bootstrap.prepare_python(tmp_path, venv_dir=str(tmp_path))
+    assert marker.read_text() == "keep this"
+
+
+@pytest.mark.parametrize("payload", [
+    [[3, 9], "TARGET", "/base"],
+    [[3, 13], "/base", "/base"],
+    [[3, 13], "/wrong", "/base"],
+    None, [], {"bad": "shape"}, "not metadata",
+])
+def test_rejects_bad_interpreter_probe(monkeypatch, tmp_path, payload):
+    (tmp_path / "pyvenv.cfg").touch()
+    encoded = json.dumps(payload).replace('"TARGET"', json.dumps(str(tmp_path)))
+    monkeypatch.setattr(bootstrap.subprocess, "run", Mock(return_value=SimpleNamespace(returncode=0, stdout=encoded)))
+    with pytest.raises(SystemExit, match="不是可用"):
+        bootstrap._validate_venv(tmp_path)
+
+
+def test_real_venv_keeps_its_executable_path(tmp_path):
+    target = tmp_path / "env with spaces"
+    venv.EnvBuilder(with_pip=False).create(target)
+    python = bootstrap._validate_venv(target.resolve())
+    assert python == bootstrap.venv_python(target)
+    metadata = subprocess.check_output([str(python), "-I", "-c", "import sys;print(sys.prefix)"], text=True)
+    assert Path(metadata.strip()).resolve() == target.resolve()
+
+
+def test_stdlib_creation_is_preferred(monkeypatch, tmp_path):
+    run = Mock(return_value=True)
+    monkeypatch.setattr(bootstrap, "_succeeds", run)
+    monkeypatch.setattr(bootstrap.shutil, "which", Mock(side_effect=AssertionError("no uv needed")))
+    target = tmp_path / "new"
+    bootstrap._create_venv(target, None)
+    run.assert_called_once_with([sys.executable, "-m", "venv", str(target)])
+
+
+def test_uv_fallback_is_pinned_non_destructive_and_uses_mirror(monkeypatch, tmp_path):
+    run = Mock(side_effect=[False, True])
+    monkeypatch.setattr(bootstrap, "_succeeds", run)
+    monkeypatch.setattr(bootstrap.shutil, "which", lambda name: "/tools/uv")
+    monkeypatch.setenv("UV_VENV_CLEAR", "true")
+    bootstrap._create_venv(tmp_path / "new", "https://index.invalid/simple")
+    command = run.call_args.args[0]
+    assert command[:5] == ["/tools/uv", "venv", "--seed", "--allow-existing", "--no-config"]
+    assert command[command.index("--python") + 1] == sys.executable
+    assert command[-2:] == ["--index-url", "https://index.invalid/simple"]
+    assert run.call_args.kwargs["env"]["UV_VENV_CLEAR"] == "false"
+
+
+def test_failed_creation_preserves_partial_directory(monkeypatch, tmp_path):
+    target = tmp_path / "new"
+    monkeypatch.setattr(bootstrap, "_succeeds", lambda *a, **kw: False)
+    monkeypatch.setattr(bootstrap.shutil, "which", lambda name: None)
+    with pytest.raises(SystemExit, match="python3-venv"):
+        bootstrap._create_venv(target, None)
+    assert target.is_dir()
+
+
+def test_creation_never_overwrites_existing_directory(tmp_path):
+    (tmp_path / "keep").touch()
+    with pytest.raises(SystemExit, match="无法创建"):
+        bootstrap._create_venv(tmp_path, None)
+    assert (tmp_path / "keep").exists()
+
+
+@pytest.mark.parametrize("results, count", [([True], 1), ([False, True], 2), ([False, False, True], 3)])
+def test_pip_bootstrap_only_targets_venv(monkeypatch, tmp_path, results, count):
+    run = Mock(side_effect=results)
+    monkeypatch.setattr(bootstrap, "_succeeds", run)
+    monkeypatch.setattr(bootstrap.shutil, "which", lambda name: "/tools/uv")
+    python = bootstrap.venv_python(tmp_path)
+    bootstrap._ensure_pip(python, "https://index.invalid/simple")
+    assert run.call_count == count
+    for call in run.call_args_list:
+        assert str(python) in call.args[0]
+    if count == 3:
+        assert run.call_args.args[0][-3:] == ["pip", "--index-url", "https://index.invalid/simple"]
+
+
+def test_missing_pip_fails_without_touching_system(monkeypatch, tmp_path):
+    monkeypatch.setattr(bootstrap, "_succeeds", lambda *a, **kw: False)
+    monkeypatch.setattr(bootstrap.shutil, "which", lambda name: None)
+    with pytest.raises(SystemExit, match="未向系统 Python"):
+        bootstrap._ensure_pip(bootstrap.venv_python(tmp_path), None)
+
+
+@pytest.mark.parametrize("failure", [OSError("missing"), subprocess.TimeoutExpired("python", 120)])
+def test_probe_failures_are_actionable(monkeypatch, failure):
+    monkeypatch.setattr(bootstrap.subprocess, "run", Mock(side_effect=failure))
+    assert not bootstrap._succeeds(["missing"])
+
+
+@pytest.mark.parametrize("override", [False, True])
+def test_editable_and_fallback_share_interpreter_and_options(monkeypatch, tmp_path, override):
+    run = Mock(side_effect=[SimpleNamespace(returncode=1), SimpleNamespace(returncode=0)])
+    monkeypatch.setattr(install.subprocess, "run", run)
+    monkeypatch.setattr(install.sys, "executable", str(bootstrap.venv_python(tmp_path)))
+    install.install_deps(tmp_path, "https://index.invalid/simple", break_system_packages=override)
+    for call in run.call_args_list:
+        command = call.args[0]
+        assert command[:4] == [install.sys.executable, "-m", "pip", "install"]
+        assert ("--break-system-packages" in command) is override
+        assert "https://index.invalid/simple" in command
+
+
+def test_cli_environment_flags_are_mutually_exclusive(monkeypatch):
+    monkeypatch.setattr(sys, "argv", ["install.py", "--venv-dir", "a", "--break-system-packages"])
+    with pytest.raises(SystemExit) as exc:
+        install.parse_args()
+    assert exc.value.code == 2
+
+
+@pytest.mark.parametrize("flag", ["--help", "--reset"])
+def test_help_and_reset_never_bootstrap(monkeypatch, flag):
+    monkeypatch.setattr(sys, "argv", ["install.py", flag])
+    prepare = Mock(side_effect=AssertionError("must not bootstrap"))
+    monkeypatch.setattr(install, "prepare_python", prepare)
+    monkeypatch.setattr(install, "do_reset", Mock())
+    if flag == "--help":
+        with pytest.raises(SystemExit) as exc:
+            install.main()
+        assert exc.value.code == 0
+    else:
+        install.main()
+    prepare.assert_not_called()
+
+
+def test_prepare_runs_before_pip_and_config(monkeypatch, tmp_path):
+    monkeypatch.setattr(sys, "argv", ["install.py", "--yes"])
+    prepare = Mock(side_effect=SystemExit("bootstrap boundary"))
+    monkeypatch.setattr(install, "prepare_python", prepare)
+    monkeypatch.setattr(install, "check_python", Mock())
+    monkeypatch.setattr(install, "check_running_clients", Mock())
+    monkeypatch.setattr(install, "check_pip", Mock(side_effect=AssertionError("too early")))
+    monkeypatch.setattr(install, "collect_config", Mock(side_effect=AssertionError("too early")))
+    with pytest.raises(SystemExit, match="bootstrap boundary"):
+        install.main()
+    prepare.assert_called_once()
+
+
+@pytest.mark.skipif(not hasattr(install, "RuntimeCommand"), reason="Python-only reference has no Rust CLI")
+def test_rust_never_bootstraps_or_installs_python(monkeypatch, tmp_path):
+    monkeypatch.setattr(sys, "argv", ["install.py", "--runtime", "rust", "--yes", "--no-smoke", "--no-claude", "--no-codex"])
+    for name in ("prepare_python", "check_pip", "install_deps"):
+        monkeypatch.setattr(install, name, Mock(side_effect=AssertionError(name)))
+    monkeypatch.setattr(install, "check_python", Mock())
+    monkeypatch.setattr(install, "check_running_clients", Mock())
+    monkeypatch.setattr(install, "resolve_runtime_command", lambda *a: install.RuntimeCommand("rust", "/fake/rust", []))
+    monkeypatch.setattr(install, "collect_config", lambda *a: ({}, "", ""))
+    monkeypatch.setattr(install, "summary", Mock())
+    install.main()
+    assert not (tmp_path / ".venv").exists()
+
+
+def test_real_reexec_routes_pip_http_and_stdio_to_one_venv(tmp_path):
+    """Real venv/exec/config I/O; pip, httpx and MCP server are offline doubles."""
+    repo = tmp_path / "repo with spaces"
+    repo.mkdir()
+    for name in ("install.py", "installer_env.py"):
+        shutil.copyfile(Path(install.__file__).parent / name, repo / name)
+    target = repo / ".venv"
+    venv.EnvBuilder(with_pip=False).create(target)
+    python = bootstrap.venv_python(target)
+    site = Path(subprocess.check_output(
+        [str(python), "-I", "-c", "import sysconfig;print(sysconfig.get_path('purelib'))"], text=True,
+    ).strip())
+    pip = site / "pip"
+    pip.mkdir()
+    (pip / "__init__.py").touch()
+    logger = "import os,sys,json\nfrom pathlib import Path\nwith open(os.environ['TEST_LOG'], 'a') as f: f.write(json.dumps([KIND,sys.executable,sys.prefix])+ '\\n')\n"
+    (pip / "__main__.py").write_text("KIND='pip'\n" + logger + "print('pip fixture')\n")
+    (site / "httpx.py").write_text(
+        "KIND='http'\n" + logger +
+        "class Response:\n status_code=200\n def json(self): return {'data':[{'id':'gpt-image-2'}]}\n"
+        "def get(url, **kw):\n assert kw['trust_env'] is False\n return Response()\n"
+    )
+    (repo / "server.py").write_text(
+        "KIND='server'\n" + logger +
+        "for line in sys.stdin:\n"
+        " obj=json.loads(line)\n"
+        " if obj.get('id')==1: print(json.dumps({'id':1,'result':{'protocolVersion':'2024-11-05'}}),flush=True)\n"
+        " if obj.get('id')==2: print(json.dumps({'id':2,'result':{'tools':[{'name':n} for n in "
+        + repr(sorted(install._EXPECTED_TOOLS)) + "]}}),flush=True)\n"
+    )
+    home = tmp_path / "home"
+    home.mkdir()
+    (home / ".claude.json").write_text(json.dumps({"mcpServers": {"other": {"command": "keep"}}}))
+    (home / ".codex").mkdir()
+    (home / ".codex/config.toml").write_text('[mcp_servers.other]\ncommand = "keep"\n')
+    log = tmp_path / "calls.jsonl"
+    env = {**os.environ, "HOME": str(home), "USERPROFILE": str(home),
+           "MICU_API_KEY": "sk-test-fixture", "MICU_SAVE_DIR": str(tmp_path / "images"),
+           "TEST_LOG": str(log), "VIRTUAL_ENV": str(tmp_path / "stale")}
+    env.pop("PYTHONHOME", None)
+    env.pop("PYTHONPATH", None)
+    # Simulate only the OS marker; every operation after selection uses real exec.
+    code = "import sys,installer_env,install;installer_env.externally_managed=lambda:True;sys.argv=['install.py','--yes'];install.main()"
+    result = subprocess.run([sys.executable, "-c", code], cwd=repo, env=env, capture_output=True, text=True, timeout=60)
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "tools/list OK" in result.stdout
+    assert "httpx 不可用" not in result.stdout
+    rows = [json.loads(line) for line in log.read_text().splitlines()]
+    assert {row[0] for row in rows} == {"pip", "http", "server"}
+    assert {Path(row[1]) for row in rows} == {python}
+    assert {Path(row[2]).resolve() for row in rows} == {target.resolve()}
+    claude = json.loads((home / ".claude.json").read_text())
+    assert claude["mcpServers"]["other"]["command"] == "keep"
+    assert claude["mcpServers"]["micu-image"]["command"] == str(python)
+    codex = (home / ".codex/config.toml").read_text()
+    assert 'command = "keep"' in codex
+    assert json.dumps(str(python)) in codex


### PR DESCRIPTION
## 范围

Refs #5。感谢 @tingfeng347 的报告和根因定位。

这是 **main 中 legacy Python 回滚安装器** 的兼容修复，不修改 Rust 服务、版本号、Release workflow、发布附件或 TS 分支。`python-reference` 的同类修复独立提交，避免把旧运行时整分支合回 main。

## 审计结论

问题成立：旧安装器直接对 `sys.executable` 调用 pip，在 PEP 668 系统上两条安装路径都会失败。只把依赖装进 venv 也不够，客户端 command、自检及 installer 内的 httpx key 校验必须一起使用目标解释器。

已审阅报告者 fork 的 `fix/installer-pep668-venv`（`f5d0064`）。采用自动虚拟环境的思路，但不直接 cherry-pick：原候选实现会在部分场景忽略显式 `--venv-dir`，相对路径可能进入客户端配置，损坏目录的交互重建默认允许递归删除，uv 也未固定到当前解释器。

## 实现

- 新增仅依赖标准库的 `installer_env.py`，在 pip 检查/配置收集之前选择环境并 **re-exec 原 installer**。pip、`/v1/models`、客户端 command、自检自然统一为目标 `sys.executable`，不需要给各层传解释器或另写 HTTP 子进程协议。
- 根据实际 prefix / conda-meta 识别环境，不信残留的 VIRTUAL_ENV/CONDA_PREFIX；系统 stdlib 存在 EXTERNALLY-MANAGED 时创建/复用仓库 `.venv`。
- 显式 `--venv-dir` 在 unmanaged Python 或已激活其他环境时也有效，目标转绝对路径，但不 resolve 掉 venv Python 本身的符号链接。
- 校验 pyvenv.cfg、Python >=3.10、目标 prefix；无效已有目录一律保留，不递归删除。stdlib venv 优先，uv fallback 固定 `--python`、保留现有内容并应用镜像。缺 pip 时在目标内依次尝试 ensurepip/uv。
- re-exec 清除会覆盖虚拟环境的 PYTHONHOME，设置正确 VIRTUAL_ENV/PATH；API key 不放进 argv。
- `--break-system-packages` 仅显式启用，并转发到两条 pip 路径；与 --venv-dir 互斥。修正把环境错误一概提示换镜像、reset 用系统 Python 卸载的误导。
- `--runtime rust`、`--help`、`--reset` 不创建 venv，也不安装 Python server 依赖。

## 本地验证

环境：Linux / Python 3.13.5。上传 blob SHA 与实际运行测试的文件逐一核对一致。

```text
python -m pytest -q tests/unit/test_installer_env.py tests/unit/test_install.py
42 passed

python -m py_compile install.py installer_env.py
passed
```

新增 39 项用例，包含 marker/prefix、残留环境变量、显式目录优先级、相对/空格路径、无效目录保留、uv/ensurepip fallback 路由、显式危险开关、reset/help、Rust bypass。

集成用例使用 **真实临时 venv、真实 re-exec、真实配置文件写入与 stdio 子进程**，验证 pip/httpx/server 最终解释器和 prefix 一致，Claude/Codex 保留其他 MCP 配置。**pip、httpx、MCP server 是离线 test doubles**，不是实际联网安装或远程生图测试，没有使用真实 API key。

未在本地执行完整仓库测试、Arch 实机、Windows/macOS 或真实服务调用；本地无网络、未安装完整 MCP 依赖。完整回归以仓库 CI 为准，不把上述 42 项误称为全仓库通过。

文档：`docs/python-installer.md`。此 PR 不自动关闭 #5；Python reference 修复也需一并合入。