### PR TITLE
fix(installer): python-reference 自动使用 PEP 668 安全虚拟环境

### DIFF
--- a/.github/workflows/python-legacy-ci.yml
+++ b/.github/workflows/python-legacy-ci.yml
@@ -5,6 +5,7 @@ on:
     branches: [python-reference, codex/issue-5-pep668-python]
   pull_request:
     branches: [python-reference]
+    types: [opened, synchronize, reopened, closed]
   workflow_dispatch:
 
 permissions:
@@ -21,6 +22,7 @@ env:
 
 jobs:
   reference-tests:
+    if: github.event.action != 'closed'
     name: Python ${{ matrix.python }} full reference
     runs-on: ubuntu-latest
     timeout-minutes: 15
@@ -38,6 +40,7 @@ jobs:
       - run: python tests/smoke_local.py
 
   installer-platforms:
+    if: github.event.action != 'closed'
     name: Installer on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     timeout-minutes: 15
@@ -54,6 +57,7 @@ jobs:
       - run: python -m pytest -q tests/unit/test_installer_env.py tests/unit/test_install.py
 
   pep668-system:
+    if: github.event.action != 'closed'
     name: Real distro PEP 668 install
     runs-on: ubuntu-latest
     timeout-minutes: 15
@@ -63,3 +67,55 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y python3-venv python3-pip
       - name: Real dependencies, loopback model probe, MCP stdio and reset
         run: /usr/bin/python3 tests/smoke_pep668.py
+
+  cleanup-merged-branch:
+    name: Remove merged temporary legacy branch
+    if: >-
+      github.event_name == 'pull_request' && github.event.action == 'closed' &&
+      github.event.pull_request.merged == true &&
+      github.event.pull_request.base.ref == 'python-reference' &&
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      startsWith(github.event.pull_request.head.ref, 'codex/')
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: write
+      pull-requests: read
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const pr = context.payload.pull_request;
+            const branch = pr.head.ref;
+            let tip;
+            try {
+              tip = (await github.rest.repos.getBranch({ owner, repo, branch })).data;
+            } catch (error) {
+              if (error.status === 404) return;
+              throw error;
+            }
+            if (tip.protected || tip.commit.sha !== pr.head.sha) {
+              core.info('Retained: branch is protected or has newer commits.');
+              return;
+            }
+            const base = (await github.rest.repos.getBranch({ owner, repo, branch: pr.base.ref })).data;
+            const comparison = (await github.rest.repos.compareCommitsWithBasehead({
+              owner, repo, basehead: `${pr.head.sha}...${base.commit.sha}`
+            })).data;
+            if (!['ahead', 'identical'].includes(comparison.status)) {
+              core.info('Retained: exact tip is not in target ancestry.');
+              return;
+            }
+            const open = await github.paginate(github.rest.pulls.list, {
+              owner, repo, state: 'open', per_page: 100
+            });
+            if (open.some(p => p.base.ref === branch ||
+                (p.head.repo?.full_name === context.payload.repository.full_name && p.head.ref === branch))) {
+              core.info('Retained: an open PR depends on the branch.');
+              return;
+            }
+            const current = (await github.rest.git.getRef({ owner, repo, ref: `heads/${branch}` })).data;
+            if (current.object.sha !== pr.head.sha) return;
+            await github.rest.git.deleteRef({ owner, repo, ref: `heads/${branch}` });
+            core.info(`Deleted merged temporary branch: ${branch}`);

--- a/.github/workflows/python-legacy-ci.yml
+++ b/.github/workflows/python-legacy-ci.yml
@@ -1,0 +1,65 @@
+name: Python legacy CI
+
+on:
+  push:
+    branches: [python-reference, codex/issue-5-pep668-python]
+  pull_request:
+    branches: [python-reference]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: python-legacy-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+env:
+  MICU_RUN_LIVE_TESTS: "0"
+  MICU_RUN_CONTRACT_TESTS: "0"
+  PYTHONUTF8: "1"
+
+jobs:
+  reference-tests:
+    name: Python ${{ matrix.python }} full reference
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        python: ["3.10", "3.13"]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python }}
+      - run: python -m pip install -e . pytest pytest-asyncio
+      - run: python -m pytest -q
+      - run: python tests/smoke_local.py
+
+  installer-platforms:
+    name: Installer on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-latest, windows-latest]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+      - run: python -m pip install pytest
+      - run: python -m pytest -q tests/unit/test_installer_env.py tests/unit/test_install.py
+
+  pep668-system:
+    name: Real distro PEP 668 install
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install distro venv and pip support
+        run: sudo apt-get update && sudo apt-get install -y python3-venv python3-pip
+      - name: Real dependencies, loopback model probe, MCP stdio and reset
+        run: /usr/bin/python3 tests/smoke_pep668.py

--- a/docs/python-installer.md
+++ b/docs/python-installer.md
@@ -1,0 +1,98 @@
+# Python reference installer: PEP 668 and virtual environments
+
+This is the legacy/source-tree Python installer, not the supported Rust release
+installer. New Rust installations should use the Rust binary's `install` command.
+Neither the Rust release workflow nor its artifacts are changed by this fix.
+
+## Run the correct installer for your branch
+
+On `main`, explicitly select the Python rollback runtime:
+
+```sh
+python install.py --runtime python
+```
+
+On the Python-only `python-reference` branch, there is no `--runtime` option:
+
+```sh
+python install.py
+```
+
+Both support `--yes` with `MICU_API_KEY` and optional `MICU_SAVE_DIR` environment
+variables. Do not put real keys in commands, issue reports, or screenshots.
+
+## Environment selection
+
+When the interpreter is not already in a virtual environment and its standard
+library contains the `EXTERNALLY-MANAGED` marker, the installer creates or reuses
+`<repository>/.venv`. It then restarts itself using that environment's Python.
+Dependency installation, `/v1/models` key-group validation, the startup smoke test,
+and the command written to Claude/Codex therefore use the same interpreter.
+The system interpreter does not need pip or httpx for this bootstrap.
+
+Existing venv/virtualenv environments are detected from the interpreter's prefixes;
+Conda is recognized by `conda-meta` under its actual prefix. Stale `VIRTUAL_ENV` or
+`CONDA_PREFIX` shell variables do not establish which interpreter is running.
+Without an explicit destination, an active environment or an unmanaged system
+interpreter keeps the previous installation behavior.
+
+To select a different environment, including on an unmanaged interpreter or while
+another venv is active:
+
+```sh
+python install.py --venv-dir "$HOME/venvs/micu"
+```
+
+Relative paths are relative to the current working directory and are made absolute
+before launch/configuration. Paths containing spaces are supported. No shell
+activation is required. Do not move/delete the chosen environment or this source
+checkout while a client configuration still references them.
+
+## Creating and recovering environments
+
+Creation prefers `python -m venv`. If unavailable, an installed `uv` is tried with
+`venv --seed` and an explicit `--python` matching the installer interpreter. A
+missing pip inside a valid target is bootstrapped with `ensurepip`, then an installed
+`uv` if necessary. `--mirror` / `--pypi-index` also apply to uv package downloads.
+The installer does not install uv or modify OS packages on your behalf.
+
+Existing targets must contain `pyvenv.cfg`, run Python 3.10 or later, and report the
+expected virtual-environment prefix. An invalid target is **never recursively
+deleted or automatically replaced**. Repair it manually or choose a new
+`--venv-dir`; partially created environments are preserved as well. On
+Debian/Ubuntu, a missing stdlib venv/ensurepip commonly requires the distribution's
+`python3-venv` package. Changing a package index cannot fix a PEP 668 restriction.
+
+The risky override is opt-in only:
+
+```sh
+python install.py --break-system-packages
+```
+
+This forwards the flag to both pip installation paths and may damage
+OS-managed Python packages. It cannot be combined with `--venv-dir` and is not the
+recommended workaround. The normal PEP 668 path never enables it automatically.
+
+`--help`, `--reset`, and `--runtime rust` on `main` do not create a Python environment
+or install Python server dependencies. Reset removes the managed client entries,
+not the environment or installed packages. Use the Python command from the old
+client configuration when uninstalling packages; do not assume it was system Python.
+
+## Regression coverage
+
+Run `python -m pytest -q tests/unit/test_installer_env.py`. Tests cover marker and
+prefix detection, stale activation variables, destination precedence, absolute
+paths, invalid-directory preservation, creation/pip fallback command routing,
+explicit overrides, reset/help, and the Rust bypass where available.
+
+The integration regression uses a real temporary venv, interpreter re-execution,
+client configuration writes, and stdio subprocess. Its pip, httpx, and MCP server
+are offline test doubles: it verifies interpreter routing, not real dependency
+resolution or the remote image API. No user configuration or real API credentials
+are used. Native platform CI and live-service validation are separate checks.
+
+This addresses issue #5, reported by @tingfeng347. Reference specifications:
+
+- [Externally Managed Environments](https://packaging.python.org/en/latest/specifications/externally-managed-environments/)
+- [Python venv](https://docs.python.org/3/library/venv.html)
+- [uv command reference](https://docs.astral.sh/uv/reference/cli/)

--- a/install.py
+++ b/install.py
@@ -16,6 +16,8 @@
     python install.py --baseurl https://...        # 高级: 覆盖 baseurl
     python install.py --no-codex                   # 不写 Codex 配置
     python install.py --no-claude                  # 不写 Claude 配置
+    python install.py --venv-dir ~/venvs/micu      # 指定 Python 虚拟环境
+    python install.py --break-system-packages      # 显式绕过 PEP 668 (有风险)
     python install.py --yes                        # 非交互, 全用环境变量
         MICU_API_KEY=... MICU_SAVE_DIR=... python install.py --yes
         MICU_API_KEY=... python install.py --yes
@@ -32,6 +34,8 @@ import sys
 from datetime import datetime
 from pathlib import Path
 from urllib.parse import urlsplit
+
+from installer_env import prepare_python
 
 PY_MIN = (3, 10)
 
@@ -186,9 +190,12 @@ def check_running_clients() -> None:
 
 # ---------- 依赖安装 ----------
 
-def install_deps(repo_root: Path, mirror_url: str | None) -> None:
+def install_deps(repo_root: Path, mirror_url: str | None, *,
+                 break_system_packages: bool = False) -> None:
     step("安装依赖")
     extra = ["-i", mirror_url] if mirror_url else []
+    if break_system_packages:
+        extra.append("--break-system-packages")
     if mirror_url:
         info(f"使用镜像: {mirror_url}")
     cmd = [sys.executable, "-m", "pip", "install", *extra, "-e", str(repo_root)]
@@ -201,7 +208,8 @@ def install_deps(repo_root: Path, mirror_url: str | None) -> None:
         info(" ".join(cmd2))
         rc2 = subprocess.run(cmd2).returncode
         if rc2 != 0:
-            err("pip install 失败. 国内用户可加 --mirror tsinghua 重试")
+            err("pip install 失败，请检查上方错误。网络问题可尝试 --mirror tsinghua；"
+                "环境或权限问题请使用 --venv-dir 指定可写的新目录。")
     ok("依赖就绪")
 
 
@@ -715,8 +723,7 @@ def do_reset(args: argparse.Namespace) -> None:
         info("没有任何文件被改动")
     else:
         ok(f"已处理: {touched}")
-    print("\n注意: pip 安装的包仍保留. 如需彻底卸载, 运行:")
-    print(f"  {sys.executable} -m pip uninstall -y micu-image-mcp")
+    print("\n注意: 虚拟环境和 pip 包仍保留；卸载时请使用原客户端配置 command 对应的 Python。")
 
 
 # ---------- main ----------
@@ -733,6 +740,11 @@ def parse_args() -> argparse.Namespace:
     p.add_argument("--pypi-index", default=None, help="自定义 pip index URL (覆盖 --mirror)")
     p.add_argument("--baseurl", default=DEFAULT_BASEURL,
                    help=f"米醋代理 baseurl (默认 {DEFAULT_BASEURL})")
+    environment = p.add_mutually_exclusive_group()
+    environment.add_argument("--venv-dir", default=None,
+                             help="指定 Python 虚拟环境目录；默认仅在 PEP 668 系统上使用仓库 .venv")
+    environment.add_argument("--break-system-packages", action="store_true",
+                             help="显式允许 pip 修改受保护的系统 Python (有风险)")
     p.add_argument("--reset", action="store_true",
                    help="移除已写入的 micu-image MCP 配置 (Claude + Codex), 不动 pip 包")
     return p.parse_args()
@@ -747,6 +759,12 @@ def main() -> None:
 
     print("=== 米醋画图 MCP 一键安装 ===\n")
     check_python()
+    repo_root = Path(__file__).resolve().parent
+    prepare_python(
+        repo_root, venv_dir=args.venv_dir,
+        break_system_packages=args.break_system_packages,
+        mirror_url=args.pypi_index or PIP_MIRRORS.get(args.mirror),
+    )
     check_pip()
     check_running_clients()
 
@@ -757,7 +775,7 @@ def main() -> None:
     info(f"仓库: {repo_root}")
 
     mirror_url = args.pypi_index or PIP_MIRRORS.get(args.mirror)
-    install_deps(repo_root, mirror_url)
+    install_deps(repo_root, mirror_url, break_system_packages=args.break_system_packages)
 
     env_dict, save_dir, save_root = collect_config(args.yes, args.baseurl)
 

--- a/installer_env.py
+++ b/installer_env.py
@@ -1,0 +1,163 @@
+"""Standard-library-only bootstrap for the source-tree Python installer."""
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+import sysconfig
+from pathlib import Path
+
+PY_MIN = (3, 10)
+
+
+def in_virtual_environment() -> bool:
+    """Inspect this interpreter, never stale shell activation variables."""
+    return (
+        sys.prefix != sys.base_prefix
+        or hasattr(sys, "real_prefix")
+        or (Path(sys.prefix) / "conda-meta").is_dir()
+    )
+
+
+def externally_managed() -> bool:
+    if in_virtual_environment():
+        return False
+    stdlib = sysconfig.get_path("stdlib", sysconfig.get_default_scheme())
+    return (Path(stdlib) / "EXTERNALLY-MANAGED").is_file()
+
+
+def venv_python(directory: Path) -> Path:
+    # Resolving the executable itself can follow a symlink back to system Python.
+    return directory / ("Scripts/python.exe" if os.name == "nt" else "bin/python")
+
+
+def _venv_environ(python: Path) -> dict[str, str]:
+    env = os.environ.copy()
+    env.pop("PYTHONHOME", None)  # This overrides pyvenv.cfg even with an absolute command.
+    env["VIRTUAL_ENV"] = str(python.parent.parent)
+    env["PATH"] = str(python.parent) + os.pathsep + env.get("PATH", "")
+    return env
+
+
+def _succeeds(command: list[str], *, quiet: bool = False,
+              env: dict[str, str] | None = None) -> bool:
+    try:
+        result = subprocess.run(command, capture_output=quiet, text=True,
+                                timeout=120, check=False, env=env)
+        return result.returncode == 0
+    except (OSError, subprocess.TimeoutExpired):
+        return False
+
+
+def _validate_venv(directory: Path) -> Path:
+    python = venv_python(directory)
+    message = (
+        f"{directory} 不是可用的 Python >= 3.10 虚拟环境。"
+        "已有文件保持不变；请修复该环境，或用 --venv-dir 指定新的目录。"
+    )
+    if not (directory / "pyvenv.cfg").is_file():
+        raise SystemExit(f"[ERR] {message}")
+    probe = (
+        "import json,sys;print(json.dumps([list(sys.version_info[:2]),"
+        "sys.prefix,sys.base_prefix]))"
+    )
+    try:
+        result = subprocess.run([str(python), "-I", "-c", probe],
+                                capture_output=True, text=True, timeout=15,
+                                check=False)
+        version, prefix, base_prefix = json.loads(result.stdout)
+        valid = (
+            result.returncode == 0
+            and tuple(version) >= PY_MIN
+            and prefix != base_prefix
+            and Path(prefix).resolve() == directory
+        )
+    except (OSError, subprocess.TimeoutExpired, ValueError, TypeError):
+        valid = False
+    if not valid:
+        raise SystemExit(f"[ERR] {message}")
+    return python
+
+
+def _create_venv(directory: Path, mirror_url: str | None) -> None:
+    # Claim a new directory; never clear, repair or remove a pre-existing one.
+    try:
+        directory.mkdir(parents=True, exist_ok=False)
+    except OSError as exc:
+        raise SystemExit(f"[ERR] 无法创建虚拟环境目录 {directory}: {exc}") from exc
+    print(f"[..] 创建虚拟环境: {directory}", flush=True)
+    if _succeeds([sys.executable, "-m", "venv", str(directory)]):
+        return
+    uv = shutil.which("uv")
+    if uv:
+        print("[!!] python -m venv 失败，尝试 uv venv --seed", flush=True)
+        command = [uv, "venv", "--seed", "--allow-existing", "--no-config",
+                   "--python", sys.executable, str(directory)]
+        if mirror_url:
+            command += ["--index-url", mirror_url]
+        # A shell's UV_VENV_CLEAR must not turn this fallback into a deletion.
+        env = {**os.environ, "UV_VENV_CLEAR": "false"}
+        if _succeeds(command, env=env):
+            return
+    raise SystemExit(
+        f"[ERR] 创建虚拟环境失败: {directory}。请安装发行版的 venv/ensurepip 支持"
+        "（Debian/Ubuntu 通常为 python3-venv），或安装 uv 后指定一个新目录重试。"
+        "未向系统 Python 安装依赖；部分创建的目录已保留。"
+    )
+
+
+def _ensure_pip(python: Path, mirror_url: str | None) -> None:
+    env = _venv_environ(python)
+    if _succeeds([str(python), "-m", "pip", "--version"], quiet=True, env=env):
+        return
+    if _succeeds([str(python), "-m", "ensurepip", "--upgrade"], env=env):
+        return
+    uv = shutil.which("uv")
+    if uv:
+        command = [uv, "pip", "install", "--no-config", "--python", str(python), "pip"]
+        if mirror_url:
+            command += ["--index-url", mirror_url]
+        if _succeeds(command, env=env):
+            return
+    raise SystemExit(
+        f"[ERR] 虚拟环境缺少 pip: {python}。请为此环境安装 pip/ensurepip，"
+        "或安装 uv 后重试。未向系统 Python 安装依赖。"
+    )
+
+
+def prepare_python(repo_root: Path, *, venv_dir: str | None = None,
+                   break_system_packages: bool = False,
+                   mirror_url: str | None = None) -> None:
+    """Re-exec in the selected venv so pip, HTTP probes and configs agree.
+
+    Must run before pip checks, dependency imports, prompts and config writes.
+    Rust, reset and help paths must not call this function.
+    """
+    if break_system_packages:
+        if venv_dir is not None:
+            raise SystemExit("[ERR] --venv-dir 与 --break-system-packages 不能同时使用")
+        print("[!!] 已显式启用 --break-system-packages；可能破坏系统 Python 包。", flush=True)
+        return
+    # An explicit destination takes precedence even in an unmanaged/active env.
+    if venv_dir is None:
+        if not externally_managed():
+            return
+        print("[..] 系统 Python 受 PEP 668 保护，改用仓库 .venv", flush=True)
+    directory = Path(venv_dir).expanduser() if venv_dir is not None else repo_root / ".venv"
+    directory = directory.resolve()
+    if in_virtual_environment() and Path(sys.prefix).resolve() == directory:
+        return  # The re-executed installer has arrived in its target environment.
+    if not directory.exists():
+        _create_venv(directory, mirror_url)
+    python = _validate_venv(directory)
+    _ensure_pip(python, mirror_url)
+    print(f"[..] 使用虚拟环境 Python: {python}", flush=True)
+    sys.stdout.flush()
+    sys.stderr.flush()
+    command = [str(python), str(repo_root / "install.py"), *sys.argv[1:]]
+    try:
+        os.execve(str(python), command, _venv_environ(python))
+    except OSError as exc:
+        raise SystemExit(f"[ERR] 无法启动虚拟环境 Python {python}: {exc}") from exc

--- a/installer_env.py
+++ b/installer_env.py
@@ -41,6 +41,14 @@ def _venv_environ(python: Path) -> dict[str, str]:
     return env
 
 
+def _exec_installer(executable: str, command: list[str], env: dict[str, str]) -> None:
+    if sys.platform == "win32":
+        # Windows execv* uses CRT argument joining, which loses space quoting.
+        # subprocess uses CreateProcess with proper quoting; propagate its status.
+        raise SystemExit(subprocess.run(command, env=env, check=False).returncode)
+    os.execve(executable, command, env)
+
+
 def _succeeds(command: list[str], *, quiet: bool = False,
               env: dict[str, str] | None = None) -> bool:
     try:
@@ -158,6 +166,6 @@ def prepare_python(repo_root: Path, *, venv_dir: str | None = None,
     sys.stderr.flush()
     command = [str(python), str(repo_root / "install.py"), *sys.argv[1:]]
     try:
-        os.execve(str(python), command, _venv_environ(python))
+        _exec_installer(str(python), command, _venv_environ(python))
     except OSError as exc:
         raise SystemExit(f"[ERR] 无法启动虚拟环境 Python {python}: {exc}") from exc

--- a/tests/smoke_pep668.py
+++ b/tests/smoke_pep668.py
@@ -61,7 +61,10 @@ def main() -> None:
     clean_env = {key: value for key, value in os.environ.items()
                  if not key.startswith(("MICU_", "PIP_", "PYTHON"))
                  and key not in {"VIRTUAL_ENV", "CONDA_PREFIX"}}
-    clean_env.update(PYTHONUTF8="1", PIP_DISABLE_PIP_VERSION_CHECK="1")
+    # Hosted runners may globally configure pip to break system packages.
+    # Disable config loading so this exercises the distro's default protection.
+    clean_env.update(PYTHONUTF8="1", PIP_DISABLE_PIP_VERSION_CHECK="1",
+                     PIP_CONFIG_FILE=os.devnull)
     # A nonexistent package and --no-index ensure this cannot install anything,
     # even if an unexpected pip configuration disables the PEP 668 protection.
     blocked = subprocess.run(
@@ -70,7 +73,8 @@ def main() -> None:
         capture_output=True, text=True, timeout=30, check=False,
     )
     assert blocked.returncode != 0
-    assert "externally-managed-environment" in blocked.stdout + blocked.stderr
+    assert "externally-managed-environment" in blocked.stdout + blocked.stderr, (
+        blocked.stdout + blocked.stderr)
     print("Confirmed: system pip refuses installation under PEP 668", flush=True)
     probe = "import importlib.util;print(importlib.util.find_spec('mcp'))"
     before = subprocess.check_output([sys.executable, "-I", "-c", probe], env=clean_env)

--- a/tests/smoke_pep668.py
+++ b/tests/smoke_pep668.py
@@ -1,0 +1,149 @@
+"""Real PEP 668 installer smoke; run with a distro-managed Python on Linux.
+
+Dependencies come from the configured pip index. Only /v1/models is a loopback
+fixture; the venv, pip, installed dependencies and MCP stdio server are real.
+No production key or paid image API is used. All client config is temporary.
+"""
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import sys
+import sysconfig
+import tempfile
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from threading import Thread
+
+KEY = "sk-ci-pep668-fixture"
+
+
+class ModelsHandler(BaseHTTPRequestHandler):
+    calls = 0
+
+    def do_GET(self) -> None:
+        if self.path != "/v1/models":
+            self.send_error(404)
+            return
+        if self.headers.get("Authorization") != f"Bearer {KEY}":
+            self.send_error(401)
+            return
+        type(self).calls += 1
+        body = json.dumps({"data": [{"id": "gpt-image-2"}]}).encode()
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, fmt: str, *args: object) -> None:
+        pass
+
+
+def run(command: list[str], *, cwd: Path, env: dict[str, str]) -> str:
+    result = subprocess.run(command, cwd=cwd, env=env, capture_output=True,
+                            text=True, encoding="utf-8", timeout=300, check=False)
+    print(result.stdout, end="", flush=True)
+    if result.returncode:
+        print(result.stderr, file=sys.stderr, flush=True)
+        raise AssertionError(f"Command failed ({result.returncode}): {command}")
+    return result.stdout
+
+
+def main() -> None:
+    marker = Path(sysconfig.get_path("stdlib")) / "EXTERNALLY-MANAGED"
+    assert sys.prefix == sys.base_prefix, "Run with system Python, not a venv"
+    assert marker.is_file(), "This smoke requires a real PEP 668 marker"
+    marker_before = marker.read_bytes()
+    source = Path(__file__).resolve().parents[1]
+    clean_env = {key: value for key, value in os.environ.items()
+                 if not key.startswith(("MICU_", "PIP_", "PYTHON"))
+                 and key not in {"VIRTUAL_ENV", "CONDA_PREFIX"}}
+    clean_env.update(PYTHONUTF8="1", PIP_DISABLE_PIP_VERSION_CHECK="1")
+    # A nonexistent package and --no-index ensure this cannot install anything,
+    # even if an unexpected pip configuration disables the PEP 668 protection.
+    blocked = subprocess.run(
+        [sys.executable, "-m", "pip", "install", "--no-index", "--no-deps",
+         "micu-pep668-ci-nonexistent"], env=clean_env,
+        capture_output=True, text=True, timeout=30, check=False,
+    )
+    assert blocked.returncode != 0
+    assert "externally-managed-environment" in blocked.stdout + blocked.stderr
+    print("Confirmed: system pip refuses installation under PEP 668", flush=True)
+    probe = "import importlib.util;print(importlib.util.find_spec('mcp'))"
+    before = subprocess.check_output([sys.executable, "-I", "-c", probe], env=clean_env)
+
+    with tempfile.TemporaryDirectory(prefix="micu pep668 ") as temporary:
+        root = Path(temporary)
+        repo = root / "repo with spaces"
+        shutil.copytree(source, repo, ignore=shutil.ignore_patterns(
+            ".git", ".venv", "__pycache__", ".pytest_cache", "target", "output",
+            "*.egg-info", "build", "dist",
+        ))
+        home = root / "home"
+        (home / ".codex").mkdir(parents=True)
+        claude = home / ".claude.json"
+        codex = home / ".codex" / "config.toml"
+        claude.write_text(json.dumps({"theme": "dark", "mcpServers": {
+            "other": {"command": "keep"}}}), encoding="utf-8")
+        codex.write_text('[mcp_servers.other]\ncommand = "keep"\n', encoding="utf-8")
+        env = {**clean_env, "HOME": str(home), "USERPROFILE": str(home),
+               "MICU_API_KEY": KEY, "MICU_SAVE_DIR": str(root / "images"),
+               "VIRTUAL_ENV": str(root / "stale-IDE-environment"),
+               "CONDA_PREFIX": str(root / "stale-conda-environment")}
+        httpd = ThreadingHTTPServer(("127.0.0.1", 0), ModelsHandler)
+        thread = Thread(target=httpd.serve_forever, daemon=True)
+        thread.start()
+        try:
+            baseurl = f"http://127.0.0.1:{httpd.server_port}"
+            command = [sys.executable, str(repo / "install.py"), "--yes",
+                       "--baseurl", baseurl]
+            python = repo / ".venv" / "bin" / "python"
+            original_cfg = None
+            for _ in range(2):
+                output = run(command, cwd=repo, env=env)
+                assert "tools/list OK" in output, "Real MCP stdio smoke did not pass"
+                assert "httpx 不可用" not in output, "Model validation was skipped"
+                cfg = (repo / ".venv" / "pyvenv.cfg").read_bytes()
+                if original_cfg is not None:
+                    assert cfg == original_cfg, "Existing venv was unexpectedly recreated"
+                original_cfg = cfg
+                parsed = json.loads(claude.read_text(encoding="utf-8"))
+                assert parsed["theme"] == "dark"
+                assert parsed["mcpServers"]["other"]["command"] == "keep"
+                assert parsed["mcpServers"]["micu-image"]["command"] == str(python)
+                toml = codex.read_text(encoding="utf-8")
+                assert 'command = "keep"' in toml
+                assert f"command = {json.dumps(str(python))}" in toml
+                assert toml.count("[mcp_servers.micu-image]") == 1
+            assert ModelsHandler.calls >= 2, "Both real httpx model probes must run"
+            metadata = json.loads(run([str(python), "-I", "-c",
+                "import json,sys,mcp,httpx,pip,PIL;print(json.dumps({"
+                "'prefix':sys.prefix,'base':sys.base_prefix,'files':"
+                "[mcp.__file__,httpx.__file__,pip.__file__,PIL.__file__]}))"],
+                cwd=repo, env=env))
+            venv = (repo / ".venv").resolve()
+            assert Path(metadata["prefix"]).resolve() == venv
+            assert metadata["prefix"] != metadata["base"]
+            assert all(Path(path).resolve().is_relative_to(venv)
+                       for path in metadata["files"])
+            run([sys.executable, str(repo / "install.py"), "--reset"], cwd=repo, env=env)
+            assert json.loads(claude.read_text(encoding="utf-8"))["mcpServers"] == {
+                "other": {"command": "keep"}}
+            assert codex.read_text(encoding="utf-8").strip() == (
+                '[mcp_servers.other]\ncommand = "keep"')
+            assert python.is_file(), "Reset must preserve the installed environment"
+        finally:
+            httpd.shutdown()
+            httpd.server_close()
+            thread.join(timeout=5)
+    assert marker.read_bytes() == marker_before
+    after = subprocess.check_output([sys.executable, "-I", "-c", probe], env=clean_env)
+    assert before == after, "System Python package visibility changed"
+    print("PEP 668 smoke passed: real install/reuse/httpx/MCP/config/reset; system unchanged")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/unit/test_installer_env.py
+++ b/tests/unit/test_installer_env.py
@@ -64,7 +64,7 @@ def test_selects_absolute_target_and_reexecs(monkeypatch, tmp_path, managed, exp
     monkeypatch.setattr(bootstrap, "_create_venv", create)
     monkeypatch.setattr(bootstrap, "_validate_venv", bootstrap.venv_python)
     monkeypatch.setattr(bootstrap, "_ensure_pip", ensure)
-    monkeypatch.setattr(bootstrap.os, "execve", execute)
+    monkeypatch.setattr(bootstrap, "_exec_installer", execute)
     monkeypatch.setattr(sys, "argv", ["install.py", "--yes"])
     monkeypatch.setenv("MICU_API_KEY", "sk-test-fixture")
     monkeypatch.setenv("PYTHONHOME", "/stale-python-home")
@@ -97,7 +97,7 @@ def test_explicit_target_can_switch_from_active_venv(monkeypatch, tmp_path):
     monkeypatch.setattr(bootstrap, "_validate_venv", bootstrap.venv_python)
     monkeypatch.setattr(bootstrap, "_ensure_pip", Mock())
     execute = Mock()
-    monkeypatch.setattr(bootstrap.os, "execve", execute)
+    monkeypatch.setattr(bootstrap, "_exec_installer", execute)
     bootstrap.prepare_python(tmp_path, venv_dir=str(tmp_path / "new"))
     assert execute.call_args.args[0] == str(bootstrap.venv_python(tmp_path / "new"))
 
@@ -106,7 +106,7 @@ def test_already_in_explicit_target_does_not_loop(monkeypatch, tmp_path):
     monkeypatch.setattr(bootstrap, "in_virtual_environment", lambda: True)
     monkeypatch.setattr(bootstrap.sys, "prefix", str(tmp_path))
     execute = Mock(side_effect=AssertionError("re-exec loop"))
-    monkeypatch.setattr(bootstrap.os, "execve", execute)
+    monkeypatch.setattr(bootstrap, "_exec_installer", execute)
     bootstrap.prepare_python(tmp_path, venv_dir=str(tmp_path))
     execute.assert_not_called()
 
@@ -336,3 +336,26 @@ def test_real_reexec_routes_pip_http_and_stdio_to_one_venv(tmp_path):
     codex = (home / ".codex/config.toml").read_text()
     assert 'command = "keep"' in codex
     assert json.dumps(str(python)) in codex
+
+
+@pytest.mark.parametrize("returncode", [0, 7])
+def test_windows_restart_quotes_arguments_and_propagates_status(monkeypatch, returncode):
+    monkeypatch.setattr(bootstrap.sys, "platform", "win32")
+    command = ["C:/env with spaces/python.exe", "C:/repo with spaces/install.py", "--yes"]
+    env = {"VIRTUAL_ENV": "C:/env with spaces"}
+    run = Mock(return_value=SimpleNamespace(returncode=returncode))
+    monkeypatch.setattr(bootstrap.subprocess, "run", run)
+    with pytest.raises(SystemExit) as exc:
+        bootstrap._exec_installer(command[0], command, env)
+    assert exc.value.code == returncode
+    run.assert_called_once_with(command, env=env, check=False)
+
+
+def test_posix_restart_replaces_current_process(monkeypatch):
+    monkeypatch.setattr(bootstrap.sys, "platform", "linux")
+    command = ["/env with spaces/bin/python", "/repo with spaces/install.py"]
+    env = {"VIRTUAL_ENV": "/env with spaces"}
+    execute = Mock()
+    monkeypatch.setattr(bootstrap.os, "execve", execute)
+    bootstrap._exec_installer(command[0], command, env)
+    execute.assert_called_once_with(command[0], command, env)

--- a/tests/unit/test_installer_env.py
+++ b/tests/unit/test_installer_env.py
@@ -1,0 +1,338 @@
+"""Offline regressions for issue #5; no user config or real API keys are used."""
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import sys
+from types import SimpleNamespace
+from unittest.mock import Mock
+import venv
+
+import pytest
+
+import install
+import installer_env as bootstrap
+
+
+def system_python(monkeypatch, tmp_path):
+    monkeypatch.setattr(bootstrap.sys, "prefix", str(tmp_path / "system"))
+    monkeypatch.setattr(bootstrap.sys, "base_prefix", str(tmp_path / "system"))
+    monkeypatch.delattr(bootstrap.sys, "real_prefix", raising=False)
+    monkeypatch.setattr(bootstrap.sysconfig, "get_path", lambda *a: str(tmp_path))
+
+
+def test_marker_and_stale_activation_variables(monkeypatch, tmp_path):
+    system_python(monkeypatch, tmp_path)
+    monkeypatch.setenv("VIRTUAL_ENV", str(tmp_path / "unrelated"))
+    monkeypatch.setenv("CONDA_PREFIX", str(tmp_path / "unrelated"))
+    assert not bootstrap.externally_managed()
+    (tmp_path / "EXTERNALLY-MANAGED").write_text("[externally-managed]\n")
+    assert bootstrap.externally_managed()
+
+
+def test_marker_directory_is_not_a_marker_file(monkeypatch, tmp_path):
+    system_python(monkeypatch, tmp_path)
+    (tmp_path / "EXTERNALLY-MANAGED").mkdir()
+    assert not bootstrap.externally_managed()
+
+
+@pytest.mark.parametrize("kind", ["venv", "virtualenv", "conda"])
+def test_actual_environments_ignore_marker(monkeypatch, tmp_path, kind):
+    system_python(monkeypatch, tmp_path)
+    (tmp_path / "EXTERNALLY-MANAGED").touch()
+    if kind == "venv":
+        monkeypatch.setattr(bootstrap.sys, "prefix", str(tmp_path / "active"))
+    elif kind == "virtualenv":
+        monkeypatch.setattr(bootstrap.sys, "real_prefix", "/base", raising=False)
+    else:
+        (Path(bootstrap.sys.prefix) / "conda-meta").mkdir(parents=True)
+    assert bootstrap.in_virtual_environment()
+    assert not bootstrap.externally_managed()
+
+
+@pytest.mark.parametrize("managed,explicit", [(True, None), (False, "custom env"), (True, "custom env")])
+def test_selects_absolute_target_and_reexecs(monkeypatch, tmp_path, managed, explicit):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(bootstrap, "externally_managed", lambda: managed)
+    monkeypatch.setattr(bootstrap, "in_virtual_environment", lambda: False)
+    create = Mock()
+    ensure = Mock()
+    execute = Mock()
+    monkeypatch.setattr(bootstrap, "_create_venv", create)
+    monkeypatch.setattr(bootstrap, "_validate_venv", bootstrap.venv_python)
+    monkeypatch.setattr(bootstrap, "_ensure_pip", ensure)
+    monkeypatch.setattr(bootstrap.os, "execve", execute)
+    monkeypatch.setattr(sys, "argv", ["install.py", "--yes"])
+    monkeypatch.setenv("MICU_API_KEY", "sk-test-fixture")
+    monkeypatch.setenv("PYTHONHOME", "/stale-python-home")
+    bootstrap.prepare_python(tmp_path, venv_dir=explicit, mirror_url="https://index.invalid/simple")
+    directory = (tmp_path / (explicit or ".venv")).resolve()
+    python = bootstrap.venv_python(directory)
+    create.assert_called_once_with(directory, "https://index.invalid/simple")
+    ensure.assert_called_once_with(python, "https://index.invalid/simple")
+    executable, argv, env = execute.call_args.args
+    assert executable == str(python)
+    assert argv == [str(python), str(tmp_path / "install.py"), "--yes"]
+    assert "sk-test-fixture" not in repr(argv)
+    assert env["MICU_API_KEY"] == "sk-test-fixture"
+    assert "PYTHONHOME" not in env
+    assert env["VIRTUAL_ENV"] == str(directory)
+
+
+def test_unmanaged_default_does_nothing(monkeypatch, tmp_path):
+    monkeypatch.setattr(bootstrap, "externally_managed", lambda: False)
+    create = Mock(side_effect=AssertionError("must not create"))
+    monkeypatch.setattr(bootstrap, "_create_venv", create)
+    bootstrap.prepare_python(tmp_path)
+    create.assert_not_called()
+
+
+def test_explicit_target_can_switch_from_active_venv(monkeypatch, tmp_path):
+    monkeypatch.setattr(bootstrap, "in_virtual_environment", lambda: True)
+    monkeypatch.setattr(bootstrap.sys, "prefix", str(tmp_path / "old"))
+    monkeypatch.setattr(bootstrap, "_create_venv", Mock())
+    monkeypatch.setattr(bootstrap, "_validate_venv", bootstrap.venv_python)
+    monkeypatch.setattr(bootstrap, "_ensure_pip", Mock())
+    execute = Mock()
+    monkeypatch.setattr(bootstrap.os, "execve", execute)
+    bootstrap.prepare_python(tmp_path, venv_dir=str(tmp_path / "new"))
+    assert execute.call_args.args[0] == str(bootstrap.venv_python(tmp_path / "new"))
+
+
+def test_already_in_explicit_target_does_not_loop(monkeypatch, tmp_path):
+    monkeypatch.setattr(bootstrap, "in_virtual_environment", lambda: True)
+    monkeypatch.setattr(bootstrap.sys, "prefix", str(tmp_path))
+    execute = Mock(side_effect=AssertionError("re-exec loop"))
+    monkeypatch.setattr(bootstrap.os, "execve", execute)
+    bootstrap.prepare_python(tmp_path, venv_dir=str(tmp_path))
+    execute.assert_not_called()
+
+
+def test_break_system_is_explicit_and_conflicts_with_venv(monkeypatch, tmp_path, capsys):
+    create = Mock(side_effect=AssertionError("must not create"))
+    monkeypatch.setattr(bootstrap, "_create_venv", create)
+    bootstrap.prepare_python(tmp_path, break_system_packages=True)
+    assert "--break-system-packages" in capsys.readouterr().out
+    with pytest.raises(SystemExit, match="不能同时使用"):
+        bootstrap.prepare_python(tmp_path, venv_dir="target", break_system_packages=True)
+    create.assert_not_called()
+
+
+def test_invalid_existing_directory_is_preserved(monkeypatch, tmp_path):
+    marker = tmp_path / "important.txt"
+    marker.write_text("keep this")
+    with pytest.raises(SystemExit, match="已有文件保持不变"):
+        bootstrap.prepare_python(tmp_path, venv_dir=str(tmp_path))
+    assert marker.read_text() == "keep this"
+
+
+@pytest.mark.parametrize("payload", [
+    [[3, 9], "TARGET", "/base"],
+    [[3, 13], "/base", "/base"],
+    [[3, 13], "/wrong", "/base"],
+    None, [], {"bad": "shape"}, "not metadata",
+])
+def test_rejects_bad_interpreter_probe(monkeypatch, tmp_path, payload):
+    (tmp_path / "pyvenv.cfg").touch()
+    encoded = json.dumps(payload).replace('"TARGET"', json.dumps(str(tmp_path)))
+    monkeypatch.setattr(bootstrap.subprocess, "run", Mock(return_value=SimpleNamespace(returncode=0, stdout=encoded)))
+    with pytest.raises(SystemExit, match="不是可用"):
+        bootstrap._validate_venv(tmp_path)
+
+
+def test_real_venv_keeps_its_executable_path(tmp_path):
+    target = tmp_path / "env with spaces"
+    venv.EnvBuilder(with_pip=False).create(target)
+    python = bootstrap._validate_venv(target.resolve())
+    assert python == bootstrap.venv_python(target)
+    metadata = subprocess.check_output([str(python), "-I", "-c", "import sys;print(sys.prefix)"], text=True)
+    assert Path(metadata.strip()).resolve() == target.resolve()
+
+
+def test_stdlib_creation_is_preferred(monkeypatch, tmp_path):
+    run = Mock(return_value=True)
+    monkeypatch.setattr(bootstrap, "_succeeds", run)
+    monkeypatch.setattr(bootstrap.shutil, "which", Mock(side_effect=AssertionError("no uv needed")))
+    target = tmp_path / "new"
+    bootstrap._create_venv(target, None)
+    run.assert_called_once_with([sys.executable, "-m", "venv", str(target)])
+
+
+def test_uv_fallback_is_pinned_non_destructive_and_uses_mirror(monkeypatch, tmp_path):
+    run = Mock(side_effect=[False, True])
+    monkeypatch.setattr(bootstrap, "_succeeds", run)
+    monkeypatch.setattr(bootstrap.shutil, "which", lambda name: "/tools/uv")
+    monkeypatch.setenv("UV_VENV_CLEAR", "true")
+    bootstrap._create_venv(tmp_path / "new", "https://index.invalid/simple")
+    command = run.call_args.args[0]
+    assert command[:5] == ["/tools/uv", "venv", "--seed", "--allow-existing", "--no-config"]
+    assert command[command.index("--python") + 1] == sys.executable
+    assert command[-2:] == ["--index-url", "https://index.invalid/simple"]
+    assert run.call_args.kwargs["env"]["UV_VENV_CLEAR"] == "false"
+
+
+def test_failed_creation_preserves_partial_directory(monkeypatch, tmp_path):
+    target = tmp_path / "new"
+    monkeypatch.setattr(bootstrap, "_succeeds", lambda *a, **kw: False)
+    monkeypatch.setattr(bootstrap.shutil, "which", lambda name: None)
+    with pytest.raises(SystemExit, match="python3-venv"):
+        bootstrap._create_venv(target, None)
+    assert target.is_dir()
+
+
+def test_creation_never_overwrites_existing_directory(tmp_path):
+    (tmp_path / "keep").touch()
+    with pytest.raises(SystemExit, match="无法创建"):
+        bootstrap._create_venv(tmp_path, None)
+    assert (tmp_path / "keep").exists()
+
+
+@pytest.mark.parametrize("results, count", [([True], 1), ([False, True], 2), ([False, False, True], 3)])
+def test_pip_bootstrap_only_targets_venv(monkeypatch, tmp_path, results, count):
+    run = Mock(side_effect=results)
+    monkeypatch.setattr(bootstrap, "_succeeds", run)
+    monkeypatch.setattr(bootstrap.shutil, "which", lambda name: "/tools/uv")
+    python = bootstrap.venv_python(tmp_path)
+    bootstrap._ensure_pip(python, "https://index.invalid/simple")
+    assert run.call_count == count
+    for call in run.call_args_list:
+        assert str(python) in call.args[0]
+    if count == 3:
+        assert run.call_args.args[0][-3:] == ["pip", "--index-url", "https://index.invalid/simple"]
+
+
+def test_missing_pip_fails_without_touching_system(monkeypatch, tmp_path):
+    monkeypatch.setattr(bootstrap, "_succeeds", lambda *a, **kw: False)
+    monkeypatch.setattr(bootstrap.shutil, "which", lambda name: None)
+    with pytest.raises(SystemExit, match="未向系统 Python"):
+        bootstrap._ensure_pip(bootstrap.venv_python(tmp_path), None)
+
+
+@pytest.mark.parametrize("failure", [OSError("missing"), subprocess.TimeoutExpired("python", 120)])
+def test_probe_failures_are_actionable(monkeypatch, failure):
+    monkeypatch.setattr(bootstrap.subprocess, "run", Mock(side_effect=failure))
+    assert not bootstrap._succeeds(["missing"])
+
+
+@pytest.mark.parametrize("override", [False, True])
+def test_editable_and_fallback_share_interpreter_and_options(monkeypatch, tmp_path, override):
+    run = Mock(side_effect=[SimpleNamespace(returncode=1), SimpleNamespace(returncode=0)])
+    monkeypatch.setattr(install.subprocess, "run", run)
+    monkeypatch.setattr(install.sys, "executable", str(bootstrap.venv_python(tmp_path)))
+    install.install_deps(tmp_path, "https://index.invalid/simple", break_system_packages=override)
+    for call in run.call_args_list:
+        command = call.args[0]
+        assert command[:4] == [install.sys.executable, "-m", "pip", "install"]
+        assert ("--break-system-packages" in command) is override
+        assert "https://index.invalid/simple" in command
+
+
+def test_cli_environment_flags_are_mutually_exclusive(monkeypatch):
+    monkeypatch.setattr(sys, "argv", ["install.py", "--venv-dir", "a", "--break-system-packages"])
+    with pytest.raises(SystemExit) as exc:
+        install.parse_args()
+    assert exc.value.code == 2
+
+
+@pytest.mark.parametrize("flag", ["--help", "--reset"])
+def test_help_and_reset_never_bootstrap(monkeypatch, flag):
+    monkeypatch.setattr(sys, "argv", ["install.py", flag])
+    prepare = Mock(side_effect=AssertionError("must not bootstrap"))
+    monkeypatch.setattr(install, "prepare_python", prepare)
+    monkeypatch.setattr(install, "do_reset", Mock())
+    if flag == "--help":
+        with pytest.raises(SystemExit) as exc:
+            install.main()
+        assert exc.value.code == 0
+    else:
+        install.main()
+    prepare.assert_not_called()
+
+
+def test_prepare_runs_before_pip_and_config(monkeypatch, tmp_path):
+    monkeypatch.setattr(sys, "argv", ["install.py", "--yes"])
+    prepare = Mock(side_effect=SystemExit("bootstrap boundary"))
+    monkeypatch.setattr(install, "prepare_python", prepare)
+    monkeypatch.setattr(install, "check_python", Mock())
+    monkeypatch.setattr(install, "check_running_clients", Mock())
+    monkeypatch.setattr(install, "check_pip", Mock(side_effect=AssertionError("too early")))
+    monkeypatch.setattr(install, "collect_config", Mock(side_effect=AssertionError("too early")))
+    with pytest.raises(SystemExit, match="bootstrap boundary"):
+        install.main()
+    prepare.assert_called_once()
+
+
+@pytest.mark.skipif(not hasattr(install, "RuntimeCommand"), reason="Python-only reference has no Rust CLI")
+def test_rust_never_bootstraps_or_installs_python(monkeypatch, tmp_path):
+    monkeypatch.setattr(sys, "argv", ["install.py", "--runtime", "rust", "--yes", "--no-smoke", "--no-claude", "--no-codex"])
+    for name in ("prepare_python", "check_pip", "install_deps"):
+        monkeypatch.setattr(install, name, Mock(side_effect=AssertionError(name)))
+    monkeypatch.setattr(install, "check_python", Mock())
+    monkeypatch.setattr(install, "check_running_clients", Mock())
+    monkeypatch.setattr(install, "resolve_runtime_command", lambda *a: install.RuntimeCommand("rust", "/fake/rust", []))
+    monkeypatch.setattr(install, "collect_config", lambda *a: ({}, "", ""))
+    monkeypatch.setattr(install, "summary", Mock())
+    install.main()
+    assert not (tmp_path / ".venv").exists()
+
+
+def test_real_reexec_routes_pip_http_and_stdio_to_one_venv(tmp_path):
+    """Real venv/exec/config I/O; pip, httpx and MCP server are offline doubles."""
+    repo = tmp_path / "repo with spaces"
+    repo.mkdir()
+    for name in ("install.py", "installer_env.py"):
+        shutil.copyfile(Path(install.__file__).parent / name, repo / name)
+    target = repo / ".venv"
+    venv.EnvBuilder(with_pip=False).create(target)
+    python = bootstrap.venv_python(target)
+    site = Path(subprocess.check_output(
+        [str(python), "-I", "-c", "import sysconfig;print(sysconfig.get_path('purelib'))"], text=True,
+    ).strip())
+    pip = site / "pip"
+    pip.mkdir()
+    (pip / "__init__.py").touch()
+    logger = "import os,sys,json\nfrom pathlib import Path\nwith open(os.environ['TEST_LOG'], 'a') as f: f.write(json.dumps([KIND,sys.executable,sys.prefix])+ '\\n')\n"
+    (pip / "__main__.py").write_text("KIND='pip'\n" + logger + "print('pip fixture')\n")
+    (site / "httpx.py").write_text(
+        "KIND='http'\n" + logger +
+        "class Response:\n status_code=200\n def json(self): return {'data':[{'id':'gpt-image-2'}]}\n"
+        "def get(url, **kw):\n assert kw['trust_env'] is False\n return Response()\n"
+    )
+    (repo / "server.py").write_text(
+        "KIND='server'\n" + logger +
+        "for line in sys.stdin:\n"
+        " obj=json.loads(line)\n"
+        " if obj.get('id')==1: print(json.dumps({'id':1,'result':{'protocolVersion':'2024-11-05'}}),flush=True)\n"
+        " if obj.get('id')==2: print(json.dumps({'id':2,'result':{'tools':[{'name':n} for n in "
+        + repr(sorted(install._EXPECTED_TOOLS)) + "]}}),flush=True)\n"
+    )
+    home = tmp_path / "home"
+    home.mkdir()
+    (home / ".claude.json").write_text(json.dumps({"mcpServers": {"other": {"command": "keep"}}}))
+    (home / ".codex").mkdir()
+    (home / ".codex/config.toml").write_text('[mcp_servers.other]\ncommand = "keep"\n')
+    log = tmp_path / "calls.jsonl"
+    env = {**os.environ, "HOME": str(home), "USERPROFILE": str(home),
+           "MICU_API_KEY": "sk-test-fixture", "MICU_SAVE_DIR": str(tmp_path / "images"),
+           "TEST_LOG": str(log), "VIRTUAL_ENV": str(tmp_path / "stale")}
+    env.pop("PYTHONHOME", None)
+    env.pop("PYTHONPATH", None)
+    # Simulate only the OS marker; every operation after selection uses real exec.
+    code = "import sys,installer_env,install;installer_env.externally_managed=lambda:True;sys.argv=['install.py','--yes'];install.main()"
+    result = subprocess.run([sys.executable, "-c", code], cwd=repo, env=env, capture_output=True, text=True, timeout=60)
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "tools/list OK" in result.stdout
+    assert "httpx 不可用" not in result.stdout
+    rows = [json.loads(line) for line in log.read_text().splitlines()]
+    assert {row[0] for row in rows} == {"pip", "http", "server"}
+    assert {Path(row[1]) for row in rows} == {python}
+    assert {Path(row[2]).resolve() for row in rows} == {target.resolve()}
+    claude = json.loads((home / ".claude.json").read_text())
+    assert claude["mcpServers"]["other"]["command"] == "keep"
+    assert claude["mcpServers"]["micu-image"]["command"] == str(python)
+    codex = (home / ".codex/config.toml").read_text()
+    assert 'command = "keep"' in codex
+    assert json.dumps(str(python)) in codex


### PR DESCRIPTION
Refs #5。配套 main 修复为 #7，Windows/真实环境验收补充为 #9。感谢 @tingfeng347 的问题报告和 PEP 668 根因定位。

## 范围与审计
只修复 Python-only 的 python-reference，不合并 Rust 迁移代码、不添加 --runtime 参数、不修改 Rust/TS 服务、版本号或 Release 工作流。

旧 installer 直接向系统 Python 装包，PEP 668 会阻止安装。只切 pip 目标不够：模型探测、客户端 command 和自检必须使用同一解释器。采用自动 venv 的方向，但未照搬候选补丁：显式 --venv-dir 优先、路径绝对化、无效已有目录不删除、uv 固定当前解释器。

## 最终实现
- 标准库 bootstrap 在 pip/配置检查前选择环境，重新执行 installer；系统 Python 无需预装 pip/httpx。
- PEP 668 默认创建或复用仓库 .venv；不信残留 VIRTUAL_ENV/CONDA_PREFIX，验证实际 prefix / conda-meta。
- 校验 pyvenv.cfg、Python >=3.10、真实 venv prefix；保留现有文件及 venv Python 符号链接路径。
- stdlib venv 优先，uv --seed fallback 固定解释器，缺 pip 时在目标环境内用 ensurepip/uv。
- 清除干扰目标的 PYTHONHOME，设置目标 PATH/VIRTUAL_ENV；key 不进入 argv。
- Windows CI 额外暴露了 execve 的空格路径拆分问题，已改用 subprocess 正确引用参数并传播子进程返回码；POSIX 保留 execve。
- --break-system-packages 仅显式启用，覆盖两条 pip 安装路径，与 --venv-dir 互斥；help/reset 不创建环境。
- 新增独立 Python legacy CI，以及仅在合并后、分支无新提交/保护/依赖且精确 tip 已保留在目标历史时执行的临时 codex 分支清理。

## 验证（最终 head 3b18702）
GitHub Actions run **34365807728**：所有 5 个验证 job 成功。
- Ubuntu / Python 3.10：完整 pytest + 本地 MCP smoke 通过。
- Ubuntu / Python 3.13：完整 pytest + 本地 MCP smoke 通过。
- macOS / Python 3.13：安装器回归通过。
- Windows / Python 3.13：安装器回归通过，含真实带空格路径 venv 跨进程测试。
- Ubuntu distro Python：真实 PEP 668 拒绝系统 pip，自动创建/复用 venv，真实 pip 下载并安装依赖，真实 httpx /v1/models 探测，实际 MCP stdio 握手和 tools/list，配置保留与 reset，均通过。

真实环境 smoke 只有模型端点是 loopback fixture，pip/httpx/MCP/venv 不是替身；未使用生产 key 或付费生图 API。为避免 hosted runner 的全局 pip 配置污染前置验证，测试禁用了 pip 配置加载。未宣称 Arch 实机或付费生图验收。

本地 Linux / Python 3.13.5：共享测试 41 passed, 1 skipped（唯一 skip 为此 Python-only 分支不适用的 Rust CLI 用例）。

运行方式：`python install.py`，非 `--runtime python`。文档：docs/python-installer.md。
