### PR TITLE
fix(installer): 补齐 Windows 重启与真实 PEP 668 回滚验证

### DIFF
--- a/.github/workflows/python-installer-ci.yml
+++ b/.github/workflows/python-installer-ci.yml
@@ -1,0 +1,60 @@
+name: Python installer CI
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - install.py
+      - installer_env.py
+      - tests/unit/test_install*.py
+      - tests/smoke_pep668.py
+      - .github/workflows/python-installer-ci.yml
+  pull_request:
+    branches: [main]
+    paths:
+      - install.py
+      - installer_env.py
+      - tests/unit/test_install*.py
+      - tests/smoke_pep668.py
+      - .github/workflows/python-installer-ci.yml
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: python-installer-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+env:
+  MICU_RUN_LIVE_TESTS: "0"
+  MICU_RUN_CONTRACT_TESTS: "0"
+  PYTHONUTF8: "1"
+
+jobs:
+  installer-platforms:
+    name: Installer on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+      - run: python -m pip install pytest
+      - run: python -m pytest -q tests/unit/test_installer_env.py tests/unit/test_install.py
+
+  pep668-system:
+    name: Real distro PEP 668 rollback install
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install distro venv and pip support
+        run: sudo apt-get update && sudo apt-get install -y python3-venv python3-pip
+      - name: Real dependencies, loopback model probe, MCP stdio and reset
+        run: /usr/bin/python3 tests/smoke_pep668.py

--- a/installer_env.py
+++ b/installer_env.py
@@ -41,6 +41,14 @@ def _venv_environ(python: Path) -> dict[str, str]:
     return env
 
 
+def _exec_installer(executable: str, command: list[str], env: dict[str, str]) -> None:
+    if sys.platform == "win32":
+        # Windows execv* uses CRT argument joining, which loses space quoting.
+        # subprocess uses CreateProcess with proper quoting; propagate its status.
+        raise SystemExit(subprocess.run(command, env=env, check=False).returncode)
+    os.execve(executable, command, env)
+
+
 def _succeeds(command: list[str], *, quiet: bool = False,
               env: dict[str, str] | None = None) -> bool:
     try:
@@ -158,6 +166,6 @@ def prepare_python(repo_root: Path, *, venv_dir: str | None = None,
     sys.stderr.flush()
     command = [str(python), str(repo_root / "install.py"), *sys.argv[1:]]
     try:
-        os.execve(str(python), command, _venv_environ(python))
+        _exec_installer(str(python), command, _venv_environ(python))
     except OSError as exc:
         raise SystemExit(f"[ERR] 无法启动虚拟环境 Python {python}: {exc}") from exc

--- a/tests/smoke_pep668.py
+++ b/tests/smoke_pep668.py
@@ -1,0 +1,153 @@
+"""Real PEP 668 installer smoke; run with a distro-managed Python on Linux.
+
+Dependencies come from the configured pip index. Only /v1/models is a loopback
+fixture; the venv, pip, installed dependencies and MCP stdio server are real.
+No production key or paid image API is used. All client config is temporary.
+"""
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import sys
+import sysconfig
+import tempfile
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from threading import Thread
+
+KEY = "sk-ci-pep668-fixture"
+
+
+class ModelsHandler(BaseHTTPRequestHandler):
+    calls = 0
+
+    def do_GET(self) -> None:
+        if self.path != "/v1/models":
+            self.send_error(404)
+            return
+        if self.headers.get("Authorization") != f"Bearer {KEY}":
+            self.send_error(401)
+            return
+        type(self).calls += 1
+        body = json.dumps({"data": [{"id": "gpt-image-2"}]}).encode()
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, fmt: str, *args: object) -> None:
+        pass
+
+
+def run(command: list[str], *, cwd: Path, env: dict[str, str]) -> str:
+    result = subprocess.run(command, cwd=cwd, env=env, capture_output=True,
+                            text=True, encoding="utf-8", timeout=300, check=False)
+    print(result.stdout, end="", flush=True)
+    if result.returncode:
+        print(result.stderr, file=sys.stderr, flush=True)
+        raise AssertionError(f"Command failed ({result.returncode}): {command}")
+    return result.stdout
+
+
+def main() -> None:
+    marker = Path(sysconfig.get_path("stdlib")) / "EXTERNALLY-MANAGED"
+    assert sys.prefix == sys.base_prefix, "Run with system Python, not a venv"
+    assert marker.is_file(), "This smoke requires a real PEP 668 marker"
+    marker_before = marker.read_bytes()
+    source = Path(__file__).resolve().parents[1]
+    clean_env = {key: value for key, value in os.environ.items()
+                 if not key.startswith(("MICU_", "PIP_", "PYTHON"))
+                 and key not in {"VIRTUAL_ENV", "CONDA_PREFIX"}}
+    # Hosted runners may globally configure pip to break system packages.
+    # Disable config loading so this exercises the distro's default protection.
+    clean_env.update(PYTHONUTF8="1", PIP_DISABLE_PIP_VERSION_CHECK="1",
+                     PIP_CONFIG_FILE=os.devnull)
+    # A nonexistent package and --no-index ensure this cannot install anything,
+    # even if an unexpected pip configuration disables the PEP 668 protection.
+    blocked = subprocess.run(
+        [sys.executable, "-m", "pip", "install", "--no-index", "--no-deps",
+         "micu-pep668-ci-nonexistent"], env=clean_env,
+        capture_output=True, text=True, timeout=30, check=False,
+    )
+    assert blocked.returncode != 0
+    assert "externally-managed-environment" in blocked.stdout + blocked.stderr, (
+        blocked.stdout + blocked.stderr)
+    print("Confirmed: system pip refuses installation under PEP 668", flush=True)
+    probe = "import importlib.util;print(importlib.util.find_spec('mcp'))"
+    before = subprocess.check_output([sys.executable, "-I", "-c", probe], env=clean_env)
+
+    with tempfile.TemporaryDirectory(prefix="micu pep668 ") as temporary:
+        root = Path(temporary)
+        repo = root / "repo with spaces"
+        shutil.copytree(source, repo, ignore=shutil.ignore_patterns(
+            ".git", ".venv", "__pycache__", ".pytest_cache", "target", "output",
+            "*.egg-info", "build", "dist",
+        ))
+        home = root / "home"
+        (home / ".codex").mkdir(parents=True)
+        claude = home / ".claude.json"
+        codex = home / ".codex" / "config.toml"
+        claude.write_text(json.dumps({"theme": "dark", "mcpServers": {
+            "other": {"command": "keep"}}}), encoding="utf-8")
+        codex.write_text('[mcp_servers.other]\ncommand = "keep"\n', encoding="utf-8")
+        env = {**clean_env, "HOME": str(home), "USERPROFILE": str(home),
+               "MICU_API_KEY": KEY, "MICU_SAVE_DIR": str(root / "images"),
+               "VIRTUAL_ENV": str(root / "stale-IDE-environment"),
+               "CONDA_PREFIX": str(root / "stale-conda-environment")}
+        httpd = ThreadingHTTPServer(("127.0.0.1", 0), ModelsHandler)
+        thread = Thread(target=httpd.serve_forever, daemon=True)
+        thread.start()
+        try:
+            baseurl = f"http://127.0.0.1:{httpd.server_port}"
+            command = [sys.executable, str(repo / "install.py"), "--yes",
+                       "--baseurl", baseurl]
+            python = repo / ".venv" / "bin" / "python"
+            original_cfg = None
+            for _ in range(2):
+                output = run(command, cwd=repo, env=env)
+                assert "tools/list OK" in output, "Real MCP stdio smoke did not pass"
+                assert "httpx 不可用" not in output, "Model validation was skipped"
+                cfg = (repo / ".venv" / "pyvenv.cfg").read_bytes()
+                if original_cfg is not None:
+                    assert cfg == original_cfg, "Existing venv was unexpectedly recreated"
+                original_cfg = cfg
+                parsed = json.loads(claude.read_text(encoding="utf-8"))
+                assert parsed["theme"] == "dark"
+                assert parsed["mcpServers"]["other"]["command"] == "keep"
+                assert parsed["mcpServers"]["micu-image"]["command"] == str(python)
+                toml = codex.read_text(encoding="utf-8")
+                assert 'command = "keep"' in toml
+                assert f"command = {json.dumps(str(python))}" in toml
+                assert toml.count("[mcp_servers.micu-image]") == 1
+            assert ModelsHandler.calls >= 2, "Both real httpx model probes must run"
+            metadata = json.loads(run([str(python), "-I", "-c",
+                "import json,sys,mcp,httpx,pip,PIL;print(json.dumps({"
+                "'prefix':sys.prefix,'base':sys.base_prefix,'files':"
+                "[mcp.__file__,httpx.__file__,pip.__file__,PIL.__file__]}))"],
+                cwd=repo, env=env))
+            venv = (repo / ".venv").resolve()
+            assert Path(metadata["prefix"]).resolve() == venv
+            assert metadata["prefix"] != metadata["base"]
+            assert all(Path(path).resolve().is_relative_to(venv)
+                       for path in metadata["files"])
+            run([sys.executable, str(repo / "install.py"), "--reset"], cwd=repo, env=env)
+            assert json.loads(claude.read_text(encoding="utf-8"))["mcpServers"] == {
+                "other": {"command": "keep"}}
+            assert codex.read_text(encoding="utf-8").strip() == (
+                '[mcp_servers.other]\ncommand = "keep"')
+            assert python.is_file(), "Reset must preserve the installed environment"
+        finally:
+            httpd.shutdown()
+            httpd.server_close()
+            thread.join(timeout=5)
+    assert marker.read_bytes() == marker_before
+    after = subprocess.check_output([sys.executable, "-I", "-c", probe], env=clean_env)
+    assert before == after, "System Python package visibility changed"
+    print("PEP 668 smoke passed: real install/reuse/httpx/MCP/config/reset; system unchanged")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/unit/test_installer_env.py
+++ b/tests/unit/test_installer_env.py
@@ -64,7 +64,7 @@ def test_selects_absolute_target_and_reexecs(monkeypatch, tmp_path, managed, exp
     monkeypatch.setattr(bootstrap, "_create_venv", create)
     monkeypatch.setattr(bootstrap, "_validate_venv", bootstrap.venv_python)
     monkeypatch.setattr(bootstrap, "_ensure_pip", ensure)
-    monkeypatch.setattr(bootstrap.os, "execve", execute)
+    monkeypatch.setattr(bootstrap, "_exec_installer", execute)
     monkeypatch.setattr(sys, "argv", ["install.py", "--yes"])
     monkeypatch.setenv("MICU_API_KEY", "sk-test-fixture")
     monkeypatch.setenv("PYTHONHOME", "/stale-python-home")
@@ -97,7 +97,7 @@ def test_explicit_target_can_switch_from_active_venv(monkeypatch, tmp_path):
     monkeypatch.setattr(bootstrap, "_validate_venv", bootstrap.venv_python)
     monkeypatch.setattr(bootstrap, "_ensure_pip", Mock())
     execute = Mock()
-    monkeypatch.setattr(bootstrap.os, "execve", execute)
+    monkeypatch.setattr(bootstrap, "_exec_installer", execute)
     bootstrap.prepare_python(tmp_path, venv_dir=str(tmp_path / "new"))
     assert execute.call_args.args[0] == str(bootstrap.venv_python(tmp_path / "new"))
 
@@ -106,7 +106,7 @@ def test_already_in_explicit_target_does_not_loop(monkeypatch, tmp_path):
     monkeypatch.setattr(bootstrap, "in_virtual_environment", lambda: True)
     monkeypatch.setattr(bootstrap.sys, "prefix", str(tmp_path))
     execute = Mock(side_effect=AssertionError("re-exec loop"))
-    monkeypatch.setattr(bootstrap.os, "execve", execute)
+    monkeypatch.setattr(bootstrap, "_exec_installer", execute)
     bootstrap.prepare_python(tmp_path, venv_dir=str(tmp_path))
     execute.assert_not_called()
 
@@ -336,3 +336,26 @@ def test_real_reexec_routes_pip_http_and_stdio_to_one_venv(tmp_path):
     codex = (home / ".codex/config.toml").read_text()
     assert 'command = "keep"' in codex
     assert json.dumps(str(python)) in codex
+
+
+@pytest.mark.parametrize("returncode", [0, 7])
+def test_windows_restart_quotes_arguments_and_propagates_status(monkeypatch, returncode):
+    monkeypatch.setattr(bootstrap.sys, "platform", "win32")
+    command = ["C:/env with spaces/python.exe", "C:/repo with spaces/install.py", "--yes"]
+    env = {"VIRTUAL_ENV": "C:/env with spaces"}
+    run = Mock(return_value=SimpleNamespace(returncode=returncode))
+    monkeypatch.setattr(bootstrap.subprocess, "run", run)
+    with pytest.raises(SystemExit) as exc:
+        bootstrap._exec_installer(command[0], command, env)
+    assert exc.value.code == returncode
+    run.assert_called_once_with(command, env=env, check=False)
+
+
+def test_posix_restart_replaces_current_process(monkeypatch):
+    monkeypatch.setattr(bootstrap.sys, "platform", "linux")
+    command = ["/env with spaces/bin/python", "/repo with spaces/install.py"]
+    env = {"VIRTUAL_ENV": "/env with spaces"}
+    execute = Mock()
+    monkeypatch.setattr(bootstrap.os, "execve", execute)
+    bootstrap._exec_installer(command[0], command, env)
+    execute.assert_called_once_with(command[0], command, env)


### PR DESCRIPTION
Refs #5。#7 已合入；继续完成 #8 的跨平台验收时，Windows runner 暴露了 `os.execve` 对带空格路径的 CRT 参数拼接问题。这个配套 PR 将修正同步到 main 的 Python 回滚入口，不修改 Rust/TS 服务、版本号或 Release 工作流。

## 修改
- Windows 改用 subprocess 的正确参数引用，并将子安装器返回码向上传递；POSIX 保持 execve。
- 新增 3 项启动行为回归；保留原有真实临时 venv / 跨进程 / 配置写入测试。
- 增加 Linux、macOS、Windows 安装器 CI。
- 增加真实发行版 PEP 668 smoke：真实系统 Python 的安装限制、真实 pip 下载依赖、自动创建及复用 venv、真实 httpx /v1/models 请求、实际 MCP stdio 握手和 tools/list、Claude/Codex 配置保留及 reset。仅模型端点使用 loopback fixture，不使用生产密钥或付费生图接口。
- 测试禁用 hosted runner 的全局 pip 配置，避免环境的系统包覆盖选项污染 PEP 668 前置验证。

## 最终验证（head 4151e63）
- GitHub Actions **34365930777 / Python installer CI**：全部通过，包含 Linux/macOS/Windows 安装器回归和真实 Ubuntu distro Python PEP 668 安装、复用、模型探测、MCP stdio、配置及 reset。
- GitHub Actions **34365930591 / CI**：全部 8 个 job 通过，包含 Python 3.10/3.13 全仓库回归、Rust 1.88 MSRV、Rust fmt/clippy/tests/audit、Python/Rust 契约及 STDIO/stress 验证，以及 Linux x86_64、macOS x86_64/arm64、Windows x86_64 原生构建。
- 配套 Python-only PR #8 已合入 python-reference，最终 head 3b18702 的独立 CI **34365807728** 全部通过。
- 本地 Linux/Python 3.13.5：共享安装器测试 42 passed，语法检查通过；本地测试源码 blob SHA 与上传文件已核对一致。

验证边界：真实系统安装测试是在 Ubuntu，而不是报告者的 Arch 实机；模型端点为本地测试服务，没有调用付费生图 API。CI 构建附件不等于发布 Release，本次不新增 tag 或 Release。